### PR TITLE
Remove english labels

### DIFF
--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230627161016-thema-codelist/20230627161016-thema-codelist.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230627161016-thema-codelist/20230627161016-thema-codelist.ttl
@@ -7,9 +7,7 @@ dvcs:Thema
     a                   skos:ConceptScheme ;
     mu:uuid             "1301f00d-0f46-4ba1-8cdc-c5ccadcedf93" ;
     skos:prefLabel      "Thema"@nl ;
-    skos:prefLabel      "Theme"@en ;
     skos:definition     "Thema van een publieke dienst"@nl ;
-    skos:definition     "Theme of a public service"@en ;
     skos:hasTopConcept  dvc:BurgerOverheid ;
     skos:hasTopConcept  dvc:CultuurSportVrijeTijd ;
     skos:hasTopConcept  dvc:EconomieWerk ;
@@ -23,9 +21,7 @@ dvc:BurgerOverheid
     a                 skos:Concept ;
     mu:uuid           "6bafa98b-d7b5-4087-b46b-b94740f070e1" ;
     skos:prefLabel    "Burger en Overheid"@nl ;
-    skos:prefLabel    "Citizen and Government"@en ;
     skos:definition   "Thema: Burger en Overheid"@nl ;
-    skos:definition   "Theme: Citizen and Government"@en ;
     skos:inScheme     dvcs:Thema ;
     skos:topConceptOf dvcs:Thema .
 
@@ -33,9 +29,7 @@ dvc:CultuurSportVrijeTijd
     a                 skos:Concept ;
     mu:uuid           "194805e5-9062-4b5b-82bb-0fa4a372a10e" ;
     skos:prefLabel    "Cultuur, Sport en Vrije Tijd"@nl ;
-    skos:prefLabel    "Culture, Sport and Leisure"@en ;
     skos:definition   "Thema: Cultuur, Sport en Vrije Tijd"@nl ;
-    skos:definition   "Theme: Cultuur, Culture, Sport and Leisure"@en ;
     skos:inScheme     dvcs:Thema ;
     skos:topConceptOf dvcs:Thema .
 
@@ -43,9 +37,7 @@ dvc:EconomieWerk
     a                 skos:Concept ;
     mu:uuid           "4d034ade-f5ff-4cca-8232-62a17940940a" ;
     skos:prefLabel    "Economie en Werk"@nl ;
-    skos:prefLabel    "Economy and Work"@en ;
     skos:definition   "Thema: Economie en Werk"@nl ;
-    skos:definition   "TEconomy and Work"@en ;
     skos:inScheme     dvcs:Thema ;
     skos:topConceptOf dvcs:Thema .
 
@@ -53,9 +45,7 @@ dvc:MilieuEnergie
     a                 skos:Concept ;
     mu:uuid           "8d43e0fb-649d-49e7-b45d-2d9df6e602a8" ;
     skos:prefLabel    "Milieu en Energie"@nl ;
-    skos:prefLabel    "Environment and Energy"@en ;
     skos:definition   "Thema: Milieu en Energie"@nl ;
-    skos:definition   "Theme: Environment and Energy"@en ;
     skos:inScheme     dvcs:Thema ;
     skos:topConceptOf dvcs:Thema .
 
@@ -63,9 +53,7 @@ dvc:MobiliteitOpenbareWerken
     a                 skos:Concept ;
     mu:uuid           "5c8dde4a-4f11-4c9e-b8fd-b588cff9d630" ;
     skos:prefLabel    "Mobiliteit en Openbare Werken"@nl ;
-    skos:prefLabel    "Mobility and Public Works"@en ;
     skos:definition   "Thema: Mobiliteit en Openbare Werken"@nl ;
-    skos:definition   "Theme: Mobility and Public Works"@en ;
     skos:inScheme     dvcs:Thema ;
     skos:topConceptOf dvcs:Thema .
 
@@ -73,9 +61,7 @@ dvc:OnderwijsWetenschap
     a                 skos:Concept ;
     mu:uuid           "ac3f669c-0f32-4d81-b36d-b44a93798ca2" ;
     skos:prefLabel    "Onderwijs en Wetenschap"@nl ;
-    skos:prefLabel    "Education and Science"@en ;
     skos:definition   "Thema: Onderwijs en Wetenschap"@nl ;
-    skos:definition   "Theme: Education and Science"@en ;
     skos:inScheme     dvcs:Thema ;
     skos:topConceptOf dvcs:Thema .
 
@@ -83,9 +69,7 @@ dvc:WelzijnGezondheid
     a                 skos:Concept ;
     mu:uuid           "19b84618-7ebe-4b7f-9088-aa35a50002a6" ;
     skos:prefLabel    "Welzijn en Gezondheid"@nl ;
-    skos:prefLabel    "Well-being and Health"@en ;
     skos:definition   "Thema: Welzijn en Gezondheid"@nl ;
-    skos:definition   "Theme: -being and Health"@en ;
     skos:inScheme     dvcs:Thema ;
     skos:topConceptOf dvcs:Thema .
 
@@ -93,8 +77,6 @@ dvc:BouwenWonen
     a                 skos:Concept ;
     mu:uuid           "78c2f63d-9071-49fd-b362-551548a19dcd" ;
     skos:prefLabel    "Bouwen en Wonen"@nl ;
-    skos:prefLabel    "Building and Living"@en ;
     skos:definition   "Thema: Bouwen en Wonen"@nl ;
-    skos:definition   "Theme: Building and Living"@en ;
     skos:inScheme     dvcs:Thema ;
     skos:topConceptOf dvcs:Thema .

--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230627161047-taal-codelist/20230627161047-taal-codelist.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230627161047-taal-codelist/20230627161047-taal-codelist.ttl
@@ -7,9 +7,7 @@ dvcs:Taal
     a                   skos:ConceptScheme ;
     mu:uuid             "184ac9eb-9fbb-48b1-b13c-c5bc8794e474" ;
     skos:prefLabel      "Taal"@nl ;
-    skos:prefLabel      "Language"@en ;
     skos:definition     "Taal"@nl ;
-    skos:definition     "Language"@en ;
     skos:hasTopConcept  <http://publications.europa.eu/resource/authority/language/NLD> ;
     skos:hasTopConcept  <http://publications.europa.eu/resource/authority/language/FRA> ;
     skos:hasTopConcept  <http://publications.europa.eu/resource/authority/language/DEU> ;
@@ -19,10 +17,8 @@ dvcs:Taal
     a                 skos:Concept ;
     mu:uuid           "8cc4f33d-324d-41a0-9fe2-41039e0fa4b3" ;
     skos:prefLabel    "Nederlands"@nl ;
-    skos:prefLabel    "Dutch"@en ;
     skos:notation     "nl" ;
     skos:definition   "Nederlandse taal"@nl ;
-    skos:definition   "Dutch language"@en ;
     skos:inScheme     dvcs:Taal ;
     skos:topConceptOf dvcs:Taal .
 
@@ -30,10 +26,8 @@ dvcs:Taal
     a                 skos:Concept ;
     mu:uuid           "9d2f6025-8674-4da2-8cab-052e4f1a640e" ;
     skos:prefLabel    "Frans"@nl ;
-    skos:prefLabel    "French"@en ;
     skos:notation     "fr" ;
     skos:definition   "Franse taal"@nl ;
-    skos:definition   "French language"@en ;
     skos:inScheme     dvcs:Taal ;
     skos:topConceptOf dvcs:Taal .
 
@@ -41,10 +35,8 @@ dvcs:Taal
     a                 skos:Concept ;
     mu:uuid           "9b832c18-233d-4248-a625-a68a32aa58f7" ;
     skos:prefLabel    "Duits"@nl ;
-    skos:prefLabel    "German"@en ;
     skos:notation     "de" ;
     skos:definition   "Duitse taal"@nl ;
-    skos:definition   "German language"@en ;
     skos:inScheme     dvcs:Taal ;
     skos:topConceptOf dvcs:Taal .
 
@@ -52,9 +44,7 @@ dvcs:Taal
     a                 skos:Concept ;
     mu:uuid           "3cfc110d-e811-462d-ac3b-313e7268435b" ;
     skos:prefLabel    "Engels"@nl ;
-    skos:prefLabel    "English"@en ;
     skos:notation     "en" ;
     skos:definition   "Engelse taal"@nl ;
-    skos:definition   "English language"@en ;
     skos:inScheme     dvcs:Taal ;
     skos:topConceptOf dvcs:Taal .

--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230627162036-doelgroep-codelist/20230627162036-doelgroep-codelist.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230627162036-doelgroep-codelist/20230627162036-doelgroep-codelist.ttl
@@ -19,9 +19,7 @@ dvc:Burger
   a                 skos:Concept ;
   mu:uuid           "243480bf-c2f2-4200-8d76-58b779e39904" ;
   skos:prefLabel    "Burger"@nl ;
-  skos:prefLabel    "Citizen"@en ;
   skos:definition   "Doelgroep burgers"@nl ;
-  skos:definition   "Target audience citizens"@en ;
   skos:inScheme     dvcs:Doelgroep ;
   skos:topConceptOf dvcs:Doelgroep .
 
@@ -29,9 +27,7 @@ dvc:Onderneming
   a                 skos:Concept ;
   mu:uuid           "bcad861a-f971-4363-adc3-3811bf327f95" ;
   skos:prefLabel    "Onderneming"@nl ;
-  skos:prefLabel    "Company"@en ;
   skos:definition   "Doelgroep onderemingen"@nl ;
-  skos:definition   "Target audience companies"@en ;
   skos:inScheme     dvcs:Doelgroep ;
   skos:topConceptOf dvcs:Doelgroep .
 
@@ -39,9 +35,7 @@ dvc:Organisatie
     a                 skos:Concept ;
     mu:uuid           "98183fca-45dd-4141-a191-9a2cbdba85cb" ;
     skos:prefLabel    "Organisatie"@nl ;
-    skos:prefLabel    "Organisation"@en ;
     skos:definition   "Doelgroep organisaties"@nl ;
-    skos:definition   "Target audience organisation"@en ;
     skos:inScheme     dvcs:Doelgroep ;
     skos:topConceptOf dvcs:Doelgroep .
 
@@ -49,9 +43,7 @@ dvc:Vereniging
   a                 skos:Concept ;
   mu:uuid           "bd1e7ba5-4b12-4cb5-a303-687277897ace" ;
   skos:prefLabel    "Vereniging"@nl ;
-  skos:prefLabel    "Association"@en ;
   skos:definition   "Doelgroep verenigingen"@nl ;
-  skos:definition   "Target audience association"@en ;
   skos:inScheme     dvcs:Doelgroep ;
   skos:topConceptOf dvcs:Doelgroep .
 

--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230627162927-publicatie-kanaal-codelist/20230627162927-publicatie-kanaal-codelist.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230627162927-publicatie-kanaal-codelist/20230627162927-publicatie-kanaal-codelist.ttl
@@ -7,17 +7,13 @@ dvcs:PublicatieKanaal
   a                   skos:ConceptScheme ;
   mu:uuid             "4ba29604-88f8-4c10-a575-4d343dd0bf92" ;
   skos:prefLabel      "Publicatiekanaal"@nl ;
-  skos:prefLabel      "Publication medium"@en ;
   skos:definition     "Publicatiekanaal van een publieke dienst beschrijft op welke plaaten de dienst zichtbaar zal zijn"@nl ;
-  skos:definition     "Publication medium of a public service describes on wich sites the service is visible"@en ;
   skos:hasTopConcept  dvc:YourEurope .
 
 dvc:YourEurope
   a                 skos:Concept ;
   mu:uuid           "11146299-7808-43f4-a1c4-1f4340c8fcdf" ;
   skos:prefLabel    "Your Europe"@nl ;
-  skos:prefLabel    "Your Europe"@en ;
   skos:definition   "Publicatiekanaal: Your Europe"@nl ;
-  skos:definition   "Publication medium: Your Europe"@en ;
   skos:inScheme     dvcs:PublicatieKanaal ;
   skos:topConceptOf dvcs:PublicatieKanaal .

--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230627163222-concept-tag-codelist/20230627163222-concept-tag-codelist.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230627163222-concept-tag-codelist/20230627163222-concept-tag-codelist.ttl
@@ -7,9 +7,7 @@ dvcs:ConceptTag
   a                   skos:ConceptScheme ;
   mu:uuid             "1bc5e90b-2e30-4f4d-9d82-a44ea850cc25" ;
   skos:prefLabel      "Concept tag"@nl ;
-  skos:prefLabel      "Concept tag"@en ;
   skos:definition     "Concept tag voor een publieke dienst concept"@nl ;
-  skos:definition     "Concept tag for a public conceptual service"@en ;
   skos:hasTopConcept  dvc:YourEuropeVerplicht ;
   skos:hasTopConcept  dvc:YourEuropeAanbevolen .
 
@@ -17,9 +15,7 @@ dvc:YourEuropeVerplicht
   a                 skos:Concept ;
   mu:uuid           "f2c74dd9-e17b-4308-a3dd-164b12f7ae78" ;
   skos:prefLabel    "Your Europe verplicht"@nl ;
-  skos:prefLabel    "Your Europe required"@en ;
   skos:definition   "Concept tag: Your Europe verplicht"@nl ;
-  skos:definition   "Concept tag: Your Europe required"@en ;
   skos:inScheme     dvcs:ConceptTag ;
   skos:topConceptOf dvcs:ConceptTag .
 
@@ -27,8 +23,6 @@ dvc:YourEuropeAanbevolen
   a                 skos:Concept ;
   mu:uuid           "d17ed3a2-fa49-4c9f-9fea-b57d61818045" ;
   skos:prefLabel    "Your Europe aanbevolen"@nl ;
-  skos:prefLabel    "Your Europe recommended"@en ;
   skos:definition   "Concept tag: Your Europe aanbevolen"@nl ;
-  skos:definition   "Concept tag: Your Europe recommended"@en ;
   skos:inScheme     dvcs:ConceptTag ;
   skos:topConceptOf dvcs:ConceptTag .

--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230627163357-snapshot-type/20230627163357-snapshot-type.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230627163357-snapshot-type/20230627163357-snapshot-type.ttl
@@ -7,9 +7,7 @@ dvcs:SnapshotType
   a                   skos:ConceptScheme ;
   mu:uuid             "b0c76ee5-6b3d-42fd-a84a-f43c08aa23a7" ;
   skos:prefLabel      "Snapshot Type"@nl ;
-  skos:prefLabel      "Snapshot Type"@en ;
   skos:definition     "Type van een snapshot"@nl ;
-  skos:definition     "Type of a snapshot"@en ;
   skos:hasTopConcept  dvc:Create ;
   skos:hasTopConcept  dvc:Update ;
   skos:hasTopConcept  dvc:Delete .
@@ -18,9 +16,7 @@ dvc:Create
   a                 skos:Concept ;
   mu:uuid           "59b11af1-64b8-4e32-8a3f-f8c14c7f45dc" ;
   skos:prefLabel    "Create"@nl ;
-  skos:prefLabel    "Create"@en ;
   skos:definition   "Snapshot type: Create"@nl ;
-  skos:definition   "Snapshot type: Create"@en ;
   skos:inScheme     dvcs:SnapshotType ;
   skos:topConceptOf dvcs:SnapshotType .
 
@@ -28,9 +24,7 @@ dvc:Update
   a                 skos:Concept ;
   mu:uuid           "55b874af-c35e-49b0-aed9-2f81e62aa001" ;
   skos:prefLabel    "Update"@nl ;
-  skos:prefLabel    "Update"@en ;
   skos:definition   "Snapshot type: update"@nl ;
-  skos:definition   "Snapshot type: update"@en ;
   skos:inScheme     dvcs:SnapshotType ;
   skos:topConceptOf dvcs:SnapshotType .
 
@@ -38,8 +32,6 @@ dvc:Delete
   a                 skos:Concept ;
   mu:uuid           "c30c94af-5d3a-4480-8431-2e60022fae94" ;
   skos:prefLabel    "Delete"@nl ;
-  skos:prefLabel    "Delete"@en ;
   skos:definition   "Snapshot type: Delete"@nl ;
-  skos:definition   "Snapshot type: Delete"@en ;
   skos:inScheme     dvcs:SnapshotType ;
   skos:topConceptOf dvcs:SnapshotType .

--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230627163552-type-codelist/20230627163552-type-codelist.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230627163552-type-codelist/20230627163552-type-codelist.ttl
@@ -7,9 +7,7 @@ dvcs:Type
   a                   skos:ConceptScheme ;
   mu:uuid             "2964e59b-9f58-4de2-8051-4cabfcb2ff0c" ;
   skos:prefLabel      "Type"@nl ;
-  skos:prefLabel      "Type"@en ;
   skos:definition     "Type van een publieke dienst"@nl ;
-  skos:definition     "Type of a public service"@en ;
   skos:hasTopConcept  dvc:FinancieleVerplichting ;
   skos:hasTopConcept  dvc:Toelating ;
   skos:hasTopConcept  dvc:Bewijs ;
@@ -22,9 +20,7 @@ dvc:FinancieleVerplichting
   a                 skos:Concept ;
   mu:uuid           "90f574c2-8571-4282-995d-d00f242a6285" ;
   skos:prefLabel    "Financiële verplichting"@nl ;
-  skos:prefLabel    "Financial Obligation"@en ;
   skos:definition   "Type: Financiële verplichting"@nl ;
-  skos:definition   "Type: Financial Obligation"@en ;
   skos:inScheme     dvcs:Type ;
   skos:topConceptOf dvcs:Type .
 
@@ -32,9 +28,7 @@ dvc:Toelating
   a                 skos:Concept ;
   mu:uuid           "8092ad53-748a-433a-b509-8d446054f77d" ;
   skos:prefLabel    "Toelating"@nl ;
-  skos:prefLabel    "Admission"@en ;
   skos:definition   "Type: Toelating"@nl ;
-  skos:definition   "Type: Admission"@en ;
   skos:inScheme     dvcs:Type ;
   skos:topConceptOf dvcs:Type .
 
@@ -42,9 +36,7 @@ dvc:Bewijs
   a                 skos:Concept ;
   mu:uuid           "3776e6e3-c3a0-46b6-ac7d-a6d08c9ff799" ;
   skos:prefLabel    "Bewijs"@nl ;
-  skos:prefLabel    "Evidence"@en ;
   skos:definition   "Type: Bewijs"@nl ;
-  skos:definition   "Type: Evidence"@en ;
   skos:inScheme     dvcs:Type ;
   skos:topConceptOf dvcs:Type .
 
@@ -52,9 +44,7 @@ dvc:Voorwerp
   a                 skos:Concept ;
   mu:uuid           "dbace981-3ce2-4653-9eea-8655b0291e40" ;
   skos:prefLabel    "Voorwerp"@nl ;
-  skos:prefLabel    "Object"@en ;
   skos:definition   "Type: Voorwerp"@nl ;
-  skos:definition   "Type: Object"@en ;
   skos:inScheme     dvcs:Type ;
   skos:topConceptOf dvcs:Type .
 
@@ -62,9 +52,7 @@ dvc:AdviesBegeleiding
   a                 skos:Concept ;
   mu:uuid           "a0b6bf79-181f-4630-aa0f-9548e48ef7d5" ;
   skos:prefLabel    "Advies en begeleiding"@nl ;
-  skos:prefLabel    "Advice and Guidance"@en ;
   skos:definition   "Type: Advies en begeleiding"@nl ;
-  skos:definition   "Type: Advice and Guidance"@en ;
   skos:inScheme     dvcs:Type ;
   skos:topConceptOf dvcs:Type .
 
@@ -72,9 +60,7 @@ dvc:InfrastructuurMateriaal
   a                 skos:Concept ;
   mu:uuid           "c229e5d8-2112-4f85-a222-1758373a8234" ;
   skos:prefLabel    "Infrastructuur en materiaal"@nl ;
-  skos:prefLabel    "Infrastructure and Material"@en ;
   skos:definition   "Type: Beschikbaar stellen van infrastructuur en materiaal"@nl ;
-  skos:definition   "Type: Infrastructure and Material"@en ;
   skos:inScheme     dvcs:Type ;
   skos:topConceptOf dvcs:Type .
 
@@ -82,8 +68,6 @@ dvc:FinancieelVoordeel
   a                 skos:Concept ;
   mu:uuid           "513af53d-4898-4110-9dcc-b95e48d62dcd" ;
   skos:prefLabel    "Financieel voordeel"@nl ;
-  skos:prefLabel    "Financial Advantage"@en ;
   skos:definition   "Type: Financieel voordeel"@nl ;
-  skos:definition   "Type: Financial Advantage"@en ;
   skos:inScheme     dvcs:Type ;
   skos:topConceptOf dvcs:Type .

--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230627163743-instantie-tag-codelist/20230627163743-instantie-tag-codelist.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230627163743-instantie-tag-codelist/20230627163743-instantie-tag-codelist.ttl
@@ -7,6 +7,4 @@ dvcs:InstantieTag
   a               skos:ConceptScheme ;
   mu:uuid         "577824d0-0e66-44ef-a384-63b0bf8f849f" ;
   skos:prefLabel  "Instantie tag"@nl ;
-  skos:prefLabel  "Instance tag"@en ;
-  skos:definition "Instantie tag voor een publieke dienst"@nl ;
-  skos:definition "Instance tag of a public service"@en .
+  skos:definition "Instantie tag voor een publieke dienst"@nl .

--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230628112712-bevoegd-bestuursniveau/20230628112712-bevoegd-bestuursniveau.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230628112712-bevoegd-bestuursniveau/20230628112712-bevoegd-bestuursniveau.ttl
@@ -7,9 +7,7 @@ dvcs:BevoegdBestuursniveau
     a                   skos:ConceptScheme ;
     mu:uuid             "f242e8d1-2b11-44dd-818e-ecd4ef9fa086" ;
     skos:prefLabel      "Bevoegd bestuursniveau"@nl ;
-    skos:prefLabel      "Competent authority level"@en ;
     skos:definition     "Bevoegd bestuursniveau van een publieke dienst"@nl ;
-    skos:definition     "Competent authority level of a public service"@en ;
     skos:hasTopConcept  dvc:Europees ;
     skos:hasTopConcept  dvc:Federaal ;
     skos:hasTopConcept  dvc:Vlaams ;
@@ -20,9 +18,7 @@ dvc:Europees
     a                 skos:Concept ;
     mu:uuid           "7c19637e-a466-41cb-9d46-94259c255f9e" ;
     skos:prefLabel    "Europese overheid"@nl ;
-    skos:prefLabel    "European government"@en ;
     skos:definition   "Bevoegd bestuursniveau: Europese overheid"@nl ;
-    skos:definition   "Competent authority level: European government"@en ;
     skos:inScheme     dvcs:BevoegdBestuursniveau ;
     skos:topConceptOf dvcs:BevoegdBestuursniveau .
 
@@ -30,9 +26,7 @@ dvc:Federaal
     a                 skos:Concept ;
     mu:uuid           "306098ed-3eca-4bce-8539-8ad8fe336195" ;
     skos:prefLabel    "Federale overheid"@nl ;
-    skos:prefLabel    "Federal government"@en ;
     skos:definition   "Bevoegd bestuursniveau: Federale overheid"@nl ;
-    skos:definition   "Competent authority level: Federal government"@en ;
     skos:inScheme     dvcs:BevoegdBestuursniveau ;
     skos:topConceptOf dvcs:BevoegdBestuursniveau .
 
@@ -40,9 +34,7 @@ dvc:Vlaams
     a                 skos:Concept ;
     mu:uuid           "51e44e9f-de20-4992-9dcd-54547c1b5030" ;
     skos:prefLabel    "Vlaamse overheid"@nl ;
-    skos:prefLabel    "Flemish government"@en ;
     skos:definition   "Bevoegd bestuursniveau: Vlaamse overheid"@nl ;
-    skos:definition   "Competent authority level: Flemish government"@en ;
     skos:inScheme     dvcs:BevoegdBestuursniveau ;
     skos:topConceptOf dvcs:BevoegdBestuursniveau .
 
@@ -50,9 +42,7 @@ dvc:Provinciaal
     a                 skos:Concept ;
     mu:uuid           "3761b126-a38d-4c8c-ad23-7853238ea5f8" ;
     skos:prefLabel    "Provinciale overheid"@nl ;
-    skos:prefLabel    "Provincial government"@en ;
     skos:definition   "Bevoegd bestuursniveau: Provinciale overheid"@nl ;
-    skos:definition   "Competent authority level: Provincial government"@en ;
     skos:inScheme     dvcs:BevoegdBestuursniveau ;
     skos:topConceptOf dvcs:BevoegdBestuursniveau .
 
@@ -60,8 +50,6 @@ dvc:Lokaal
     a                 skos:Concept ;
     mu:uuid           "3da40f8f-3978-4903-ab45-3fb1de2f1e0b" ;
     skos:prefLabel    "Lokale overheid"@nl ;
-    skos:prefLabel    "Local government"@en ;
     skos:definition   "Bevoegd bestuursniveau: Lokale overheid"@nl ;
-    skos:definition   "Competent authority level: Local government"@en ;
     skos:inScheme     dvcs:BevoegdBestuursniveau ;
     skos:topConceptOf dvcs:BevoegdBestuursniveau .

--- a/config/migrations/2023/20230627153144-lpdc-codelists/20230628113208-uitvoerend-bestuursniveau/20230628113208-uitvoerend-bestuursniveau.ttl
+++ b/config/migrations/2023/20230627153144-lpdc-codelists/20230628113208-uitvoerend-bestuursniveau/20230628113208-uitvoerend-bestuursniveau.ttl
@@ -21,9 +21,7 @@ dvc:Europees
     a                 skos:Concept ;
     mu:uuid           "248216f5-c81b-4f57-9ac2-5bd38e03ec2d" ;
     skos:prefLabel    "Europese overheid"@nl ;
-    skos:prefLabel    "European government"@en ;
     skos:definition   "Uitvoerend bestuursniveau: Europese overheid"@nl ;
-    skos:definition   "Executing authority level: European government"@en ;
     skos:inScheme     dvcs:UitvoerendBestuursniveau ;
     skos:topConceptOf dvcs:UitvoerendBestuursniveau .
 
@@ -31,9 +29,7 @@ dvc:Federaal
     a                 skos:Concept ;
     mu:uuid           "6f33a017-3edb-45eb-9d15-91188e213ef0" ;
     skos:prefLabel    "Federale overheid"@nl ;
-    skos:prefLabel    "Federal government"@en ;
     skos:definition   "Uitvoerend bestuursniveau: Federale overheid"@nl ;
-    skos:definition   "Executing authority level: Federal government"@en ;
     skos:inScheme     dvcs:UitvoerendBestuursniveau ;
     skos:topConceptOf dvcs:UitvoerendBestuursniveau .
 
@@ -41,9 +37,7 @@ dvc:Vlaams
     a                 skos:Concept ;
     mu:uuid           "75e3398e-7a87-48eb-af5f-f0bc81a6a5a4" ;
     skos:prefLabel    "Vlaamse overheid"@nl ;
-    skos:prefLabel    "Flemish government"@en ;
     skos:definition   "Uitvoerend bestuursniveau: Vlaamse overheid"@nl ;
-    skos:definition   "Executing authority level: Flemish government"@en ;
     skos:inScheme     dvcs:UitvoerendBestuursniveau ;
     skos:topConceptOf dvcs:UitvoerendBestuursniveau .
 
@@ -51,9 +45,7 @@ dvc:Provinciaal
     a                 skos:Concept ;
     mu:uuid           "c021df61-7d8c-4ab3-9d16-3034c059e7d6" ;
     skos:prefLabel    "Provinciale overheid"@nl ;
-    skos:prefLabel    "Provincial government"@en ;
     skos:definition   "Uitvoerend bestuursniveau: Provinciale overheid"@nl ;
-    skos:definition   "Executing authority level: Provincial government"@en ;
     skos:inScheme     dvcs:UitvoerendBestuursniveau ;
     skos:topConceptOf dvcs:UitvoerendBestuursniveau .
 
@@ -61,9 +53,7 @@ dvc:Lokaal
     a                 skos:Concept ;
     mu:uuid           "d300ae35-ec48-4879-af04-3fb5eab459bf" ;
     skos:prefLabel    "Lokale overheid"@nl ;
-    skos:prefLabel    "Local government"@en ;
     skos:definition   "Uitvoerend bestuursniveau: Lokale overheid"@nl ;
-    skos:definition   "Executing authority level: Local government"@en ;
     skos:inScheme     dvcs:UitvoerendBestuursniveau ;
     skos:topConceptOf dvcs:UitvoerendBestuursniveau .
 
@@ -71,8 +61,6 @@ dvc:Derden
     a                 skos:Concept ;
     mu:uuid           "e3a61966-0c33-4070-b0ae-9046e9b54e4c" ;
     skos:prefLabel    "Derden"@nl ;
-    skos:prefLabel    "Third parties"@en ;
     skos:definition   "Uitvoerend bestuursniveau: Derden"@nl ;
-    skos:definition   "Executing authority level: Third parties"@en ;
     skos:inScheme     dvcs:UitvoerendBestuursniveau ;
     skos:topConceptOf dvcs:UitvoerendBestuursniveau .


### PR DESCRIPTION
By having both Dutch and English labels inside the codelists, there is no guarantee on which one is shown to the user; it is possible in the same drop-down menu to have both English and Dutch entries, which is confusing to the user.