### PR TITLE
Change LPDC boolean types to correct configuration management

### DIFF
--- a/config/migrations/2023/20230630185710-change-lpdc-boolean-types.sparql
+++ b/config/migrations/2023/20230630185710-change-lpdc-boolean-types.sparql
@@ -1,0 +1,73 @@
+DELETE {
+  GRAPH ?g {
+    ?s <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptIsNew> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptIsNew> "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#ConceptDisplayConfiguration> ;
+      <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptIsNew> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptIsNew> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptIsNew> "false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#ConceptDisplayConfiguration> ;
+      <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptIsNew> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptInstantiated> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptInstantiated> "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#ConceptDisplayConfiguration> ;
+      <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptInstantiated> "true"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptInstantiated> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptInstantiated> "false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#ConceptDisplayConfiguration> ;
+      <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#conceptInstantiated> "false"^^<http://www.w3.org/2001/XMLSchema#boolean> .
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     environment:
       MU_SPARQL_ENDPOINT: "http://virtuoso:8890/sparql"
       DATABASE_OVERLOAD_RECOVERY: "true"
+      DATABASE_COMPATIBILITY: "Virtuoso"
       # Note: not sure whether it gets picked up properly; it is meant for healing-process which may make
       # heavy queries
       QUERY_MAX_PROCESSING_TIME: 605000
@@ -134,7 +135,7 @@ services:
   # LPDC
   ################################################################################
   lpdc-management:
-    image: lblod/lpdc-management-service:0.24.0
+    image: lblod/lpdc-management-service:0.24.1
     volumes:
       - ./config/lpdc-management:/config
       - ./data/files/lpdc:/data


### PR DESCRIPTION
This PR applies the same steps as https://github.com/lblod/app-digitaal-loket/pull/430, but uses another migration to replace the LPDC boolean types.

The migration works by searching for boolean types, having the `<http://www.w3.org/2001/XMLSchema#boolean>` type, for the `ConceptDisplayConfiguration` objects and mapping them to `<http://mu.semte.ch/vocabularies/typed-literals/boolean>`. It does so manually for the two predicates, `conceptIsNew` and `conceptInstantiated`, by manually querying for the `true` and `false` values of each predicate and mapping the old type to the new one.