### PR TITLE
Remove wasInGraph predicate

### DIFF
--- a/config/migrations/2023/20230707142328-remove-wasInGraph-predicate.sparql
+++ b/config/migrations/2023/20230707142328-remove-wasInGraph-predicate.sparql
@@ -1,0 +1,12 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?g {
+    ?s ext:wasInGraph ?graph .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s ext:wasInGraph ?graph .
+  }
+}


### PR DESCRIPTION
This predicate was added when exporting date from Loket in order to re-import bestuurseenheden, person and accounts back to their correct graphs; it is now no longer needed.