### PR TITLE
fix: correct faulty OVO code URIs for organisations

### DIFF
--- a/config/migrations/2024/20240806132638-fix-incorrect-competent-authority-uri-gent.sparql
+++ b/config/migrations/2024/20240806132638-fix-incorrect-competent-authority-uri-gent.sparql
@@ -1,0 +1,79 @@
+PREFIX euro: <http://data.europa.eu/m8g/>
+PREFIX ipdc-lpdc: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
+PREFIX schema: <http://schema.org/>
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?s ?p ?correctedUri .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s ?p ?o .
+
+    VALUES ?p {
+      euro:hasCompetentAuthority
+      ipdc-lpdc:hasExecutingAuthority
+    }
+
+    FILTER NOT EXISTS {
+      ?s schema:publication ?publicationStatus.
+    }
+
+    FILTER (STRSTARTS(STR(?o), "http://data.lblod.info/id/bestuurseenheden/OVO"))
+    BIND (IRI(REPLACE(STR(?o), "http://data.lblod.info/id/bestuurseenheden/OVO", "https://data.vlaanderen.be/id/organisatie/OVO")) AS ?correctedUri)
+  }
+  FILTER (STRSTARTS(STR(?g), "http://mu.semte.ch/graphs/organizations/"))
+}
+;
+# For already published services the status is also updated to ensure the
+# `lpdc-publish-service` picks it up.
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+    ?s schema:publication "http://lblod.data.gift/concepts/publication-status/gepubliceerd" .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?s ?p ?correctedUri .
+    ?s schema:publication "http://lblod.data.gift/concepts/publication-status/te-herpubliceren" .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s ?p ?o .
+
+    VALUES ?p {
+      euro:hasCompetentAuthority
+      ipdc-lpdc:hasExecutingAuthority
+    }
+
+    FILTER EXISTS {
+      ?s schema:publication "http://lblod.data.gift/concepts/publication-status/gepubliceerd" .
+    }
+
+    FILTER (STRSTARTS(STR(?o), "http://data.lblod.info/id/bestuurseenheden/OVO"))
+    BIND (IRI(REPLACE(STR(?o), "http://data.lblod.info/id/bestuurseenheden/OVO", "https://data.vlaanderen.be/id/organisatie/OVO")) AS ?correctedUri)
+  }
+  FILTER (STRSTARTS(STR(?g), "http://mu.semte.ch/graphs/organizations/"))
+}
+;
+# Correct the faulty URIs used by the `lpdc-management-service` to construct the
+# OVO code lists
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?correctedUri ?p ?o .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o .
+    FILTER (STRSTARTS(STR(?s), "http://data.lblod.info/id/bestuurseenheden/OVO"))
+    BIND (IRI(REPLACE(STR(?s), "http://data.lblod.info/id/bestuurseenheden/OVO", "https://data.vlaanderen.be/id/organisatie/OVO")) AS ?correctedUri)
+  }
+}


### PR DESCRIPTION
## Overview

For a while Ghent's LDES contained incorrect URIs to refer to organisations in
the organisatieregister. More specifically, the URIs where defined as
  `http://data.lblod.info/id/bestuurseenheden/OVOXXXXXX`
instead of
  `https://data.vlaanderen.be/id/organisatie/OVOXXXXXX`.
On their side, Ghent already corrected the URIs in their LDES.

This migration corrects the faulty URIs on LPDC's side for:
1. Any product or service that uses a faulty URI to refer to a competent
   authority and/or executing authority. If a service was already published its
   status is also updated such that the `lpdc-publish-service` will re-publish
   it.
2. Any faulty resource URI in the public graph such that the
   `lpdc-management-service` constructs correct code lists for competent
   authorities.


## Tickets

- LPDC-1260
- LPDC-1268