### PR TITLE
Back to `mu-javascript-template`

### DIFF
--- a/tests/docker-compose.tests.development.yml
+++ b/tests/docker-compose.tests.development.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
 
   lpdc-management:
-    image: node:20-alpine
+    image: semtech/mu-javascript-template:1.8.0
     depends_on:
       migrations:
         condition: service_healthy


### PR DESCRIPTION
As @mirdono mentioned [in a PR on the lpdc-management-service](https://github.com/lblod/lpdc-management-service/pull/44), the image version for the tests in the app also need to be changed back to the `mu-javascript-template`.