### PR TITLE
chore: bump `mu-cl-resources`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,7 @@ services:
     logging: *default-logging
 
   resource:
-    image: semtech/mu-cl-resources:feature-supply-info-on-empty-included
+    image: semtech/mu-cl-resources:1.24.0
     depends_on:
       migrations:
         condition: service_healthy


### PR DESCRIPTION
LPDC previously used a feature branch of `mu-cl-resources` which occasionally
seems to cause problems with organisation's products/services not loading. As a
quick fix the service was already bumped on production via override. This PR
is intended to make this a permanent bump.

Related to LPDC-1303