### PR TITLE
Add mock person and account for new fusies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
-
+## Unreleased
+### Backend
+- Add `mock-login` accounts for the new fusies. (LPDC-1291)
+### Deploy Notes
+#### Docker Commands
+- `drc restart migrations && drc logs -ft --tail=200 migrations`
 ## v0.21.6 (2024-09-06)
 ### Backend
 - Remove duplicate URI for IBEG. (DL-5770)

--- a/config/migrations/2024/20241112145534-add-merger-mock-accounts/20241112145534-add-merger-mock-accounts.sparql
+++ b/config/migrations/2024/20241112145534-add-merger-mock-accounts/20241112145534-add-merger-mock-accounts.sparql
@@ -1,0 +1,54 @@
+PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext:     <http://mu.semte.ch/vocabularies/ext/>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?persoon a foaf:Person ;
+      mu:uuid ?uuidPersoon ;
+      foaf:firstName ?classificatie ;
+      foaf:familyName ?naam ;
+      foaf:member ?bestuurseenheid ;
+      foaf:account ?account .
+
+    ?account a foaf:OnlineAccount ;
+      mu:uuid ?uuidAccount ;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service> ;
+      ext:sessionRole "LoketLB-LPDCGebruiker" .
+  }
+
+  GRAPH ?g {
+    ?persoon a foaf:Person ;
+      mu:uuid ?uuidPersoon ;
+      foaf:firstName ?classificatie ;
+      foaf:familyName ?naam ;
+      foaf:member ?bestuurseenheid ;
+      foaf:account ?account .
+
+    ?account a foaf:OnlineAccount ;
+      mu:uuid ?uuidAccount ;
+      foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service> ;
+      ext:sessionRole "LoketLB-LPDCGebruiker" .
+  }
+}
+WHERE {
+  ?bestuurseenheid a besluit:Bestuurseenheid ;
+    mu:uuid ?uuidOrganization ;
+    skos:prefLabel ?naam ;
+    besluit:classificatie/skos:prefLabel ?classificatie .
+
+  FILTER NOT EXISTS {
+    ?person foaf:member ?bestuurseenheid .
+  }
+
+  BIND(CONCAT(?classificatie, " ", ?naam) AS ?volledigeNaam)
+  BIND(MD5(?volledigeNaam) AS ?uuidPersoon)
+  BIND(MD5(CONCAT(?volledigeNaam,"ACCOUNT")) AS ?uuidAccount)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/persoon/", ?uuidPersoon)) AS ?persoon)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/account/", ?uuidAccount)) AS ?account)
+  BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?uuidOrganization)) AS ?g)
+}

--- a/config/migrations/2024/20241112145534-add-merger-mock-accounts/20241112145535-add-concept-display-configurations-for-ocmw-and-gemeente-pajottegem.sparql
+++ b/config/migrations/2024/20241112145534-add-merger-mock-accounts/20241112145535-add-concept-display-configurations-for-ocmw-and-gemeente-pajottegem.sparql
@@ -1,0 +1,30 @@
+INSERT {
+  GRAPH ?bestuurseenheidGraph {
+    ?concept <http://data.lblod.info/vocabularies/lpdc/hasConceptDisplayConfiguration> ?displayConfig .
+    ?displayConfig a <http://data.lblod.info/vocabularies/lpdc/ConceptDisplayConfiguration> ;
+      <http://mu.semte.ch/vocabularies/core/uuid> ?configId ;
+      <http://data.lblod.info/vocabularies/lpdc/conceptIsNew> "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> ;
+      <http://data.lblod.info/vocabularies/lpdc/conceptInstantiated> "false"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> ;
+      <http://purl.org/dc/terms/relation> ?bestuur .
+  }
+}
+WHERE {
+  VALUES ?bestuur {
+    <http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf> # OCMW Pajottegem
+    <http://data.lblod.info/id/bestuurseenheden/add1e4eb-9ec7-4ea6-af82-335aa76b7d48> # Gemeente Pajottegem
+  }
+
+  ?bestuur <http://mu.semte.ch/vocabularies/core/uuid> ?bestuurId .
+
+  ?concept a <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#ConceptualPublicService> ;
+    <http://mu.semte.ch/vocabularies/ext/hasVersionedSource> ?versionedSource .
+
+  BIND(SHA512(CONCAT(STR(?concept), STR(?bestuurId))) as ?configId)
+  BIND(IRI(CONCAT('http://data.lblod.info/id/conceptual-display-configuration/', STR(?configId))) as ?displayConfig)
+  BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", STR(?bestuurId), "/LoketLB-LPDCGebruiker")) as ?bestuurseenheidGraph)
+
+  FILTER NOT EXISTS {
+    ?concept <http://data.lblod.info/vocabularies/lpdc/hasConceptDisplayConfiguration> ?displayConfig .
+    ?displayConfig <http://purl.org/dc/terms/relation> ?bestuur .
+  }
+}


### PR DESCRIPTION
## Ticket ID

LPDC-1291

## Description

This PR adds mock login accounts/persons to the new fusiebestuuren.

## How to Test

Go to `/mock-login` and search for the following:
* `Merelbeke-Melle`
* `Beveren-Kruibeke-Zwijndrecht`
* `Nazareth-De Pinte`
* `Pajottegem`

These labels correspond to both new Gemeenten and OCMWs, so there will be a total of 8 new users.

Click on some of them => You should see an empty page.

**TODO**: Check if concept consume testing needs to happen in this PR as well.