### PR TITLE
fix: avoid duplicate scope options for products

### DIFF
--- a/config/migrations/2024/20241106152035-update-codelist-spatials-nuts-lau/20241106152457-import-nuts2024-codelist.ttl
+++ b/config/migrations/2024/20241106152035-update-codelist-spatials-nuts-lau/20241106152457-import-nuts2024-codelist.ttl
@@ -162,10 +162,8 @@ nutss:2024
     skos:hasTopConcept nuts:BE23343014 ;
     skos:hasTopConcept nuts:BE23343018 ;
     skos:hasTopConcept nuts:BE23444001 ;
-    skos:hasTopConcept nuts:BE23444001_VOOR_FUSIE_2019 ;
     skos:hasTopConcept nuts:BE23444029 ;
     skos:hasTopConcept nuts:BE23444011 ;
-    skos:hasTopConcept nuts:BE23444011_VOOR_FUSIE_2019 ;
     skos:hasTopConcept nuts:BE23444049 ;
     skos:hasTopConcept nuts:BE23444086 ;
     skos:hasTopConcept nuts:BE23444012 ;
@@ -1590,15 +1588,6 @@ nuts:BE23444001
     skos:inScheme     nutss:2024 ;
     skos:topConceptOf nutss:2024 .
 
-nuts:BE23444001_VOOR_FUSIE_2019
-    a                 skos:Concept ;
-    skos:prefLabel    "Aalter"@nl ;
-    skos:definition   "NUTS/LAU classificatie: Aalter"@nl ;
-    skos:notation     "44001" ;
-    time:hasEnd       "2018-12-31"^^xsd:date ;
-    skos:inScheme     nutss:2024 ;
-    skos:topConceptOf nutss:2024 .
-
 nuts:BE23444029
     a                 skos:Concept ;
     skos:prefLabel    "Knesselare"@nl ;
@@ -1614,15 +1603,6 @@ nuts:BE23444011
     skos:definition   "NUTS/LAU classificatie: Deinze"@nl ;
     skos:notation     "44083" ;
     time:hasBeginning "2019-01-01"^^xsd:date ;
-    skos:inScheme     nutss:2024 ;
-    skos:topConceptOf nutss:2024 .
-
-nuts:BE23444011_VOOR_FUSIE_2019
-    a                 skos:Concept ;
-    skos:prefLabel    "Deinze"@nl ;
-    skos:definition   "NUTS/LAU classificatie: Deinze"@nl ;
-    skos:notation     "44011" ;
-    time:hasEnd       "2018-12-31"^^xsd:date ;
     skos:inScheme     nutss:2024 ;
     skos:topConceptOf nutss:2024 .
 

--- a/config/migrations/2024/20241106152035-update-codelist-spatials-nuts-lau/20241106152457-import-nuts2024-codelist.ttl
+++ b/config/migrations/2024/20241106152035-update-codelist-spatials-nuts-lau/20241106152457-import-nuts2024-codelist.ttl
@@ -1012,7 +1012,7 @@ nuts:BE22171072
 
 nuts:BE22171022
     a                 skos:Concept ;
-    skos:prefLabel    "Hasselt"@nl ;
+    skos:prefLabel    "Hasselt (voor fusie 2025)"@nl ;
     skos:definition   "NUTS/LAU classificatie: Hasselt"@nl ;
     skos:notation     "71022" ;
     time:hasEnd       "2024-12-31"^^xsd:date ;
@@ -1676,7 +1676,7 @@ nuts:BE23444087
 
 nuts:BE23444034
     a                 skos:Concept ;
-    skos:prefLabel    "Lochristi"@nl ;
+    skos:prefLabel    "Lochristi (voor fusie 2025)"@nl ;
     skos:definition   "NUTS/LAU classificatie: Lochristi"@nl ;
     skos:notation     "44034" ;
     time:hasEnd       "2024-12-31"^^xsd:date ;
@@ -1934,7 +1934,7 @@ nuts:BE23646013
 
 nuts:BE23646014
     a                 skos:Concept ;
-    skos:prefLabel    "Lokeren"@nl ;
+    skos:prefLabel    "Lokeren (voor fusie 2025)"@nl ;
     skos:definition   "NUTS/LAU classificatie: Lokeren"@nl ;
     skos:notation     "46014" ;
     time:hasEnd       "2024-12-31"^^xsd:date ;
@@ -2967,7 +2967,7 @@ nuts:BE25737012
 
 nuts:BE25737015
     a                 skos:Concept ;
-    skos:prefLabel    "Tielt"@nl ;
+    skos:prefLabel    "Tielt (voor fusie 2025)"@nl ;
     skos:definition   "NUTS/LAU classificatie: Tielt"@nl ;
     skos:notation     "37015" ;
     time:hasEnd       "2024-12-31"^^xsd:date ;
@@ -2984,7 +2984,7 @@ nuts:BE25737017
 
 nuts:BE25737018
     a                 skos:Concept ;
-    skos:prefLabel    "Wingene"@nl ;
+    skos:prefLabel    "Wingene (voor fusie 2025)"@nl ;
     skos:definition   "NUTS/LAU classificatie: Wingene"@nl ;
     skos:notation     "37018" ;
     time:hasEnd       "2024-12-31"^^xsd:date ;


### PR DESCRIPTION
The 2024 NUTS code list uses the same label for different codes when the
relevant municipality is involved in a merger but does not changes its
name. This results in seemingly duplicate options when a user tries to select a
product's scope (nl. Geografisch toepassingsgebied).

## Steps to reproduce the bug
1. Log in to LPDC, any organisation with product instances will do.
2. Select a product instance from the list, any will do.
3. If the selected product has the status “Verzonden”, click the “Product
   opnieuw bewerken” button at the top of the page. On the warning that appears,
   click the button with the same text.
4. Open the "Eigenschappen" tab for the select product instance.
5. Go to the “Bevoegdheid” section, this contains the field "Geografisch
   toepassingsgebied" whose values match the NUTS code list resources.
6. For the following municipalities, the drop down list with suggestions
   contains duplicate entries:
   - Aalter
   - Deinze
   - Hasselt
   - Lochristi
   - Lokeren
   - Tielt
   - Wingene

## Proposed solutions
### Duplicate labels from 2019 mergers
For the municipalities of *Aalter* and *Deinze*, there are different NUTS codes
defined for before and after the 2019 municipality mergers. The NUTS codes for
before the 2019 mergers, those ending in `_VOOR_FUSIE_2019`, are **not** used in
LPDC. To avoid duplicate suggestions, we simply no longer import the unused NUTS
codes.

### Duplicate labels from 2025 mergers
The following 5 municipalities do **not** change their name as part of the 2025
mergers but do get a **new** NUTS code:
- Hasselt
- Lochristi
- Lokeren
- Tielt
- Wingene

In order to allow users to differentiate between the "old" and "new" scopes a
suffix " (voor fusie 2025)" is added to the labels for the NUTS codes that will
expire after 31 December 2024.

Notes:
- At least for the time being, LPDC requires having both the "old" and "new"
  NUTS codes, as the "old" ones are still referenced by products. So removing
  them is not a valid solution at the moment.
- *Antwerpen* is an exception that keeps the same NUTS code after its merger, so
  no duplicate labels for that case.

## Additional steps for DEV and TEST environments
On the TEST and DEV environments the original migration, containing the
duplicate labels, has already been executed. On these environments the already
imported data will be modified by two migrations that will be run locally on
these environments and are therefore not included in this PR. These migrations
will contain the following queries:

Delete the unused codes for *Aalter* and *Deinze*:

``` sparql
PREFIX nuts: <http://data.europa.eu/nuts/code/>

DELETE {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s ?p ?o.
  }
} WHERE {
  ?s ?p ?o.
  VALUES ?s {
    nuts:BE23444001_VOOR_FUSIE_2019 # Aalter
    nuts:BE23444011_VOOR_FUSIE_2019 # Deinze
  }
}
```

Update the labels for the 5 "old" NUTS codes:

``` sparql
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
PREFIX time: <http://www.w3.org/2006/time#>

DELETE {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s skos:prefLabel ?label.
  }
} INSERT {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s skos:prefLabel ?newLabel.
  }
} WHERE {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s skos:prefLabel ?label;
       time:hasEnd "2024-12-31"^^xsd:date.
    BIND(CONCAT(?label, " (voor fusie 2025)") AS ?newLabel)
  }
  VALUES ?s {
    <http://data.europa.eu/nuts/code/BE22171022> # Hasselt
    <http://data.europa.eu/nuts/code/BE23444034> # Lochristi
    <http://data.europa.eu/nuts/code/BE23646014> # Lokeren
    <http://data.europa.eu/nuts/code/BE25737015> # Tielt
    <http://data.europa.eu/nuts/code/BE25737018> # Wingene
  }
}
```

## Related tickets
- LPDC-1328
- LPDC-1261