### PR TITLE
chore: rename municipalities and OCMWs for 2025 mergers

### DIFF
--- a/config/migrations/2024/20241126144504-rename-merged-municipalities-and-ocmws.sparql
+++ b/config/migrations/2024/20241126144504-rename-merged-municipalities-and-ocmws.sparql
@@ -5,14 +5,24 @@ DELETE {
   GRAPH <http://mu.semte.ch/graphs/public> {
     ?organisation skos:prefLabel ?oldName.
   }
+  GRAPH ?g {
+    ?person foaf:familyName ?oldFamilyName.
+  }
 } INSERT {
   GRAPH <http://mu.semte.ch/graphs/public> {
     ?organisation skos:prefLabel ?newName.
+  }
+  GRAPH ?g {
+    ?person foaf:familyName ?newName.
   }
 } WHERE {
   GRAPH <http://mu.semte.ch/graphs/public> {
     ?organisation a besluit:Bestuurseenheid;
                   skos:prefLabel ?oldName.
+  }
+  GRAPH ?g {
+    ?person foaf:member ?organisation;
+            foaf:familyName ?oldFamilyName.
   }
   VALUES (?organisation ?newName) {
     (<http://data.lblod.info/id/bestuurseenheden/99da98a7a0087d3429b084ebfc4eb5d488c593790d4d5af7253982a2e21a6a5f> """Bilzen-Hoeselt""") # Bilzen -> Bilzen-Hoeselt (municipality)


### PR DESCRIPTION
Three municipalities, and their corresponding OCMWs, will keep the same URI in
the 2025 municipality merger but do change their name. Specifically, this is the case for the following municipalities:

| Current name | Name after merger |
| ------------ | ----------------- |
| Bilzen       | Bilzen-Hoeselt    |
| Ham          | Tessenderlo-Ham   |
| Tongeren     | Tongeren-Borgloon |


## Related tickets
- LPDC-1331