### PR TITLE
Add werkingsgebieden for new fusies

### DIFF
--- a/config/migrations/2024/20241129182951-add-werkingsgebieden-for-new-fusies.sparql
+++ b/config/migrations/2024/20241129182951-add-werkingsgebieden-for-new-fusies.sparql
@@ -1,0 +1,71 @@
+PREFIX nuts:  <http://data.europa.eu/nuts/code/>
+
+# Pajottegem
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/werkingsgebieden/92398c49-30d5-46b2-af90-37f135c89e47>
+      <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Location> ;
+      <http://mu.semte.ch/vocabularies/core/uuid> "92398c49-30d5-46b2-af90-37f135c89e47" ;
+      <http://www.w3.org/2004/02/skos/core#exactMatch> nuts:BE24123106 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <http://data.lblod.info/id/werkingsgebieden/92398c49-30d5-46b2-af90-37f135c89e47> . # OCMW Pajottegem
+
+    <http://data.lblod.info/id/bestuurseenheden/add1e4eb-9ec7-4ea6-af82-335aa76b7d48> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <http://data.lblod.info/id/werkingsgebieden/92398c49-30d5-46b2-af90-37f135c89e47> . # Gemeente Pajottegem
+  }
+}
+
+;
+
+# Beveren-Kruibeke-Zwijndrecht
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/werkingsgebieden/b97c1b58-6431-4509-ab94-3300d27759a8>
+      <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Location> ;
+      <http://mu.semte.ch/vocabularies/core/uuid> "b97c1b58-6431-4509-ab94-3300d27759a8" ;
+      <http://www.w3.org/2004/02/skos/core#exactMatch> nuts:BE23646030 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <http://data.lblod.info/id/werkingsgebieden/b97c1b58-6431-4509-ab94-3300d27759a8> . # OCMW Beveren-Kruibeke-Zwijndrecht
+
+    <http://data.lblod.info/id/bestuurseenheden/19483103-318e-435a-aa37-45e485406ee9> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <http://data.lblod.info/id/werkingsgebieden/b97c1b58-6431-4509-ab94-3300d27759a8> . # Gemeente Beveren-Kruibeke-Zwijndrecht
+  }
+}
+
+;
+
+# Merelbeke-Melle
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/werkingsgebieden/62fef519-b1de-4a0f-911a-c63a5365c17b>
+      <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Location> ;
+      <http://mu.semte.ch/vocabularies/core/uuid> "62fef519-b1de-4a0f-911a-c63a5365c17b" ;
+      <http://www.w3.org/2004/02/skos/core#exactMatch> nuts:BE23444088 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <http://data.lblod.info/id/werkingsgebieden/62fef519-b1de-4a0f-911a-c63a5365c17b> . # OCMW Merelbeke-Melle
+
+    <http://data.lblod.info/id/bestuurseenheden/b8bb293d-aa22-4b43-bda4-0b6af76e9493> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <http://data.lblod.info/id/werkingsgebieden/62fef519-b1de-4a0f-911a-c63a5365c17b> . # Gemeente Merelbeke-Melle
+  }
+}
+
+;
+
+# Nazareth-De Pinte
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/werkingsgebieden/41362ab2-5130-4160-b76b-4bfa5d9a1f59>
+      <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Location> ;
+      <http://mu.semte.ch/vocabularies/core/uuid> "41362ab2-5130-4160-b76b-4bfa5d9a1f59" ;
+      <http://www.w3.org/2004/02/skos/core#exactMatch> nuts:BE23444086 .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <http://data.lblod.info/id/werkingsgebieden/41362ab2-5130-4160-b76b-4bfa5d9a1f59> . # OCMW Nazareth-De Pinte
+
+    <http://data.lblod.info/id/bestuurseenheden/1ca65d65-54ff-4b44-b750-bd70c91191af> <http://data.vlaanderen.be/ns/besluit#werkingsgebied> <http://data.lblod.info/id/werkingsgebieden/41362ab2-5130-4160-b76b-4bfa5d9a1f59> . # Gemeente Nazareth-De Pinte
+  }
+}


### PR DESCRIPTION
## Ticket ID

LPDC-1332

## Description

This PR allows new fusiebesturen to have the `Geografische Toepassingsgebied` section immediately be prefilled with the area they are in.

## How to Test

* Log in as `Gemeente Pajottegem` for example.
* Add any random service.
* Go to the `Eigenschappen` section of the form => You will see that the field is missing.
* Check out this branch and run the migration.
* Perform the same steps and add a new service.
* You will the field is now filled with `Pajottegem`.