### PR TITLE
Bump migrations service to v0.9.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     logging: *default-logging
 
   migrations:
-    image: semtech/mu-migrations-service:0.8.0
+    image: semtech/mu-migrations-service:0.9.0
     depends_on:
       virtuoso:
         condition: service_started


### PR DESCRIPTION
## Description

This PR bumps `migrations` to `v0.9.0`.

## How to Test

Run the migrations of this repo from scratch => Migrations should complete without issues.