### PR TITLE
chore: import organisation status data from OrganisatiePortaal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## v0.23.3 (TODO)
+### Backend
+- Add organisation statuses from OP (LPDC-1340)
+### Deploy instructions
+- Execute the migration to import the organisation status data
+#### Docker commands
+- `drc restart migrations; drc logs -ft --tail=200 migrations`
+
 ## v0.23.2 (2024-12-17)
 ### Backend
 - Rename municipalities and OCMWs for 2025 municipality mergers (LPDC-1331)

--- a/config/migrations/2025/20250114112818-import-organisation-statuses/20250114112818-import-organisation-statuses--concept-scheme.graph
+++ b/config/migrations/2025/20250114112818-import-organisation-statuses/20250114112818-import-organisation-statuses--concept-scheme.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2025/20250114112818-import-organisation-statuses/20250114112818-import-organisation-statuses--concept-scheme.ttl
+++ b/config/migrations/2025/20250114112818-import-organisation-statuses/20250114112818-import-organisation-statuses--concept-scheme.ttl
@@ -1,0 +1,47 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix code: <http://lblod.data.gift/vocabularies/organisatie/> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix schemes: <http://lblod.data.gift/concept-schemes/> .
+@prefix concepts: <http://lblod.data.gift/concepts/> .
+
+schemes:b8dcb04f0d1feb86ff01cc0677363b20 rdf:type skos:ConceptScheme ;
+    mu:uuid "b8dcb04f0d1feb86ff01cc0677363b20" ;
+    skos:prefLabel "Organisatie status code" .
+
+concepts:63cc561de9188d64ba5840a42ae8f0d6 rdf:type code:OrganisatieStatusCode ;
+    mu:uuid "63cc561de9188d64ba5840a42ae8f0d6" ;
+    skos:prefLabel "Actief" ;
+    skos:inScheme schemes:b8dcb04f0d1feb86ff01cc0677363b20 ;
+    skos:topConceptOf schemes:b8dcb04f0d1feb86ff01cc0677363b20 .
+concepts:d02c4e12bf88d2fdf5123b07f29c9311 rdf:type code:OrganisatieStatusCode ;
+    mu:uuid "d02c4e12bf88d2fdf5123b07f29c9311" ;
+    skos:prefLabel "Niet Actief" ;
+    skos:inScheme schemes:b8dcb04f0d1feb86ff01cc0677363b20 ;
+    skos:topConceptOf schemes:b8dcb04f0d1feb86ff01cc0677363b20 .
+concepts:abf4fee82019f88cf122f986830621ab rdf:type code:OrganisatieStatusCode ;
+    mu:uuid "abf4fee82019f88cf122f986830621ab" ;
+    skos:prefLabel "In oprichting" ;
+    skos:inScheme schemes:b8dcb04f0d1feb86ff01cc0677363b20 ;
+    skos:topConceptOf schemes:b8dcb04f0d1feb86ff01cc0677363b20 .
+
+# Exported from OrganisatiePortaal (PROD) the query:
+# CONSTRUCT {
+#   ?s ?p ?o.
+# } WHERE {
+#   GRAPH <http://mu.semte.ch/graphs/public> {
+#     ?s ?p ?o.
+#   }
+#   VALUES ?s {
+#     <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>
+#     <http://lblod.data.gift/concepts/abf4fee82019f88cf122f986830621ab>
+#     <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>
+#
+#     <http://lblod.data.gift/concept-schemes/b8dcb04f0d1feb86ff01cc0677363b20>
+#   }
+# }
+#
+# Manual changes:
+# - renamed prefixes from nsX to something more meaningful
+# - removed link to unneeded OP-specific "OP Public Export" concept scheme
+# - improved formatting

--- a/config/migrations/2025/20250114112818-import-organisation-statuses/20250114131511-import-organisation-statuses--organisation-status-data.graph
+++ b/config/migrations/2025/20250114112818-import-organisation-statuses/20250114131511-import-organisation-statuses--organisation-status-data.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/temporary-organization-status

--- a/config/migrations/2025/20250114112818-import-organisation-statuses/20250114131511-import-organisation-statuses--organisation-status-data.ttl
+++ b/config/migrations/2025/20250114112818-import-organisation-statuses/20250114131511-import-organisation-statuses--organisation-status-data.ttl
@@ -1,0 +1,2752 @@
+# Exported from OrganisatiePortaal PROD using:
+# PREFIX regorg: <http://www.w3.org/ns/regorg#>
+# PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+# CONSTRUCT {
+#   ?org regorg:orgStatus ?status.
+# } WHERE {
+#   GRAPH ?g {
+#     ?org a besluit:Bestuurseenheid.
+#   }
+#   GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+#     ?org regorg:orgStatus ?status.
+#   }
+#   VALUES ?g {
+#     <http://mu.semte.ch/graphs/administrative-unit>
+#     <http://mu.semte.ch/graphs/shared>
+#   }
+# }
+
+@prefix ns0:	<http://www.w3.org/ns/regorg#> .
+@prefix ns1:	<http://lblod.data.gift/concepts/> .
+@prefix ns2:	<http://data.lblod.info/id/bestuurseenheden/> .
+
+<http://data.lblod.info/id/bestuurseenheden/66DB132B6ABCA6E6BF2DBBED>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/675300C180B4579ABA1BF06F>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3f1ec7f1afc4cc466bb3a7fe5bc43199bf600963ec3231e1480a23d103a438a7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/23d04e951dabc6c108803eac7e8faf08c639ba6984d1cda170f09fbd8a511855>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1086df7c6c150e427fc56e2239eed2b7e2d9d4a97abb24c00e951ec89f9bcbec>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0327a51548f73607f8a5ec11b36711a3c96703686ad93a3d632718c135c295db>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/02c739446ed9f2585fd96cb4c25743106462a589aa6d6f3e5feb088f025e6851>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/08e1b1e460bc9a9dfbd6570ab96a6b4813fbd4d9df2294dad86b11d9e4093d32>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/01f5df79d1c889c5fb42592a72d7aa50bcfc77a8d04c7f2015df993b0e479835>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/00eb231f51bd6b4f5dcc6536b2d09a174ea8583f5bf28b10bc4fc769a07e511d>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/298b13541e1e85de4b71535197aa1f3bbc4bdb67f0fe0f58ab4a7dc207af61fa>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/11e23f966461f4740579b5ac2745421c6a3c3f42a9dbd4df7bd3d3f21e44f129>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2f980d9d54c35e0a61137da4eacfe4bef20246e18983449ce15dcd3d2a83f509>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/156dad76d5d8e30d26b501d715fd237b38cbae60e76753a09d897fd317ab914c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/09f5b10fbd078fcb1e0e4910d32e47146a5eb31d8138dcbaec798309e64dd059>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1cb4914d7d6a57869d4d9cf68abe20151334b30694e6a7546c155c5beaa6ac8a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/26e9007dd8e6316c45488b1c4d5ceff1707d25e67b892f82c166ee889c0c2e41>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5679c9292547a19a6186dfccb4047045f8a9c4d24435a6daf45226b3d675558f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0c4cf1788b1bf8838ed9c7fe9839e49a1120b2dd1d005a52bc4f718c25ca06fb>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0c2d775df43f87d2048eb26c322d1bc9423e0a3f0ee7ceefd2011cdb077f12df>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/03ff483dadbae6e23f785f5b428248911bec4f5b3ce2559e960d0d8f32f15619>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1b983548dc44e39bc920a7a8ec1901b692a664865d5fee5133ae96e7281eca6f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1d43739442010a95b1910af237a4f6aa9a26ca6c9c83f646bad44a8181d407c7>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/2ad0d123f4a81787572342c394a1917b81752f42d802d1e013941f56b53bdd2a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0fa622b92c507c69fa6d4aa4ab8fc79eac8f841b4fecfb1ad27245bfb6310f50>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/003e84121111866af60611a59e13d4c478718f60472655936edec1e352a34c5f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1b11f7f11c3c74c54acf86b8c1a9b8b2865e22b8973818486045a5d3aa8dff14>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/1313d4a58f9ecf52cc7e274e3549a759b35e731973cc9f5e07562e5650f594dd>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/2564e21e3650f91625189ccb7eb055e47754a0633c54c7582a899171fef60c52>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/0a3ba641d653b436b14fde37bb6eab4f1054aa0586eb98021b723d58f6ce82fb>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/13eec34a405a478eab20b99eb813f2d0f409c0f8b28960b229637b394b82f880>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/011a6ad0efca0b7e03ca9b99bd6c636a26cbde49aa0d6844b9ebc434dc58216c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0a71e2b47c58e6d13ac628f733863543b791869395afcfe5b5c82c98ff894e3d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0bb11f642e87a81479446ebe4938947cbc35da5f7516a3d5a9667b67d5024574>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7d47cc2df885086cee43dc51b76668d566a324dc7e021180ec80788bfb76124c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6eb63a95ebb0e5fcb9e59b25a264977107e690a46a89755da1637d1427693560>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b80c00718ab23cc3676202e24a5ec9a92823d38ca970c0fd4ff6e3754b721d36
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8ef1e4a43efd913e6b09b0ddea344b7b5d723a344ad559389a55ae1ff0bebc8f>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/42887f141929197c227828071ec7dec4cb5435794fedfc7fcf901648e0ea4742>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8af37430f91603017873dbc1390eccf364bf82854f7358e9c9845498b184660f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/644341a5338a39472f7d096f3c1619ca0e8325a560f681f58896fa843cb17d2c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f4a187c72e551b9d7745e3b8602b11f12ce0fd5399c7f8aebbd4f8f42dc9c028
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bd2cfcb37561afe84b4f8b1894bf7e0f204b21931b6f9ae1d5dbbafcb6681c9b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b85b33fb0ce57e2b332599d2aaafcab35a3560b709add3cec98e21dca6cdc210
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/475062d945c58733894b4c506471bf7ce43c6fffde9a83bd5e390ad040203781>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5efa0b9c06f5b70b071e539047bd847dff555b9ce51c1b86b263018a610f5820>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/55155a78bd145df7bfa3caaa17ba491fb4dd238f4f4d2c5485bff1be96ca3036>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5116efa8-e96e-46a2-aba6-c077e9056a96>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/79606fdb21535301a493afb83e18758d21f6499355beab0099a6265fbdc700d3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/47368dce85e1d529ee837f53d1822243e7c235f0a9cac6ffe5620bb1d6758a31>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3499c07d07336622b8880bd8fd9bd49667f88d6998755cb1dc31f58012248b43>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f4641f7ba21f1a575993f1b523fb581af12269164006abeab121886037ac0cad
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/72f67d3444ab98d389f85fa57939aad373269bfe15dd47aa6c1a9a24ce1a746b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8b7e7bf05ace5bb1a68f5bc0d870e20c20f147b00bd9a3dcce3a01733d4da744>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/44c5d81bf86b888159e3c2ee2cf3fd39e4afd58c73edc27245111c8a32bf5fa0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/54c9a2a4a577fc2f6888bdf2b43d439ae59ae26a3db344546c7a713f2aab2bce>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8ed14ecd083fb231f9af0f2698de728bba3f11deb0f4ea4caf9d5c1f9e3a771b>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8df96cc548c53410332620ec1adae4591bd5340127b1332c4b902c5c3afe260d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/920b64f03ced3fc044fcdf5493bbb99573a4213f921dc92509581cea87d7a80f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/842737db3afe0bad6a72bbbdeee376fe49abe721975d549d81bb22c70bc7002d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e58e47292d23dc83547f3f272c6018439290d988dcab6d352215bad91751e1b7
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3e58880a542424b73f85c9ffba8837b0da40d8c43e936c92603cde2015f5cdae>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bf2ed8893d2ec4689b4c60b0b236edf11f381e247c535f0b12d132fc80ca1ad0
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9a187d228c5c22e402cb2186f731a5b7cce9549d3fac1e667ce59a3cb80b76c0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:db046b577b77c00cc82b51b1cdf14396364cbe1ebc0f4cfee09619bec9b0bd5e
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e41ffa04f94bb450a79793020e70d55b5fee5033a5280277998608a9d0913117
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:ccda2ffa758045bf3a9df27463b2a0bb12da6324f5f40ba7691e14932ebfa638
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/26721daac0558a8a9efee4fc9d1141733844b3a6eb0813401546eb805a978182>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b456cda7fa9b2b176adb216e5598aeeb60ff19753a5a08ade6ffd32e9a0ead89
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/393a7495daffabe3dabd5d341673287cedc58485c3c8bc273cbd058e735dfee2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/800ce18716ba451af47c2e05c2a7bdd29ab9305eaa61068629c1ea2ae6c08f4c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/70b79f6678036bf05e970aa3885d1779f143d4eab63ecf339ea6263e7e76ad1d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d168033a9bac278fa744c425e078eeabd304397f953feaaf5327b4e039aecacb
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/25c9ed309395f3dafc25ae14e5fd515a729f260eda74fa2ab8b3cb02adb85c84>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2f003f9d0696af25e0864d01b3a40d3d38249d14f253edbafe2ff106237abf1c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/319db6e275f281d0280da90d6f6aba3462f4e47b6f53a34639feb91015a5822b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/38dc63f50a4f7ea61ef741d8944a874a59ba84b69b9ff3e73f69680da2c6ef37>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e580b3ee33ff28d93f803e7f70cdb1d99bf6ae9d56b0f630fd7b6837adf8cd4c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b4aa8ca2a4daa74ef8297b0b4dba2ad292e73da5337e20c65066860279751307
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/780e50a94a76c850a8f88c7e01427de38b445dcc6ebe79815a6d0f44adc530bc>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5ee75cb5b6f031391189ad0f6ce6fefbc35f7fbfe1e50b7ab57dcab25ccfa139>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/698c9e2b9495736610180524294fa5f583cc9fd9da535aa6caba1cb29f0e53b0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5d6fcfda3248cb295893be604a9d3e31f0899b2daebb3bd3b30b371d098ee635>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e3293ebdd5233f4afc47124685940336937eb18f5692edb22fe8850cb38cc7b3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4b93b99b2a80c6ce4e64850589a8c0163fc055b074b061a64add3e1af303f1fe>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b070cde79629e0c3c5ed3d693fe06b6b066f75299244c224edb42a54fdfad265
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d9f7c0ab4920fdecf3f9a60b92e921b5ca07248fcb0eac2113eb97392ddd6c6c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/51689560fe677738ed03e8a14dc01723d0f865c488f5f47c388622f332241e2d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/69e815e62d4698903b7db1df39f372317439cb28a8c4ca62aa6bfd1acaa62266>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d760812063231cc45ced3fa65a7cd54920329178c8df7e891aa12db442e6606a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7c51e88f8a89d42e054368a7c5da3c16ecce3b86ea63918a0d7e1d46fbdde2b9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a6fae65d377aa9e3f2575d4bc0f7cf53df2b5e80ca1823433885557ff0b18834
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e3fc7eb1c6f50aa4277e0ae180b002eddf243dab630e9278996df9951316da68
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8fd5ea9aeb61c45ec79986650bee55142b2f8a599d5d611dd578114216a58430>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a71e8220eac329de3fca638aa1b8236309730ef15de41e7f84820d50b582a5ca
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a0393ba99ecc1a0e05d93966aaad42b07980efa5dc90f72106f3fb5954215e18
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/25fc615f81f2032ee7126108474e842b418c890c3755f9e1efc58ac6dc59d1fc>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7d457bc3985fbb70ba748c121043c89d498a3926e8c59ffdf9438c2896791248>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cd64084b7a4eed361bc4f6194a95a708564b6962f068a68d2e535c7d2dcb4820
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c26acb21f9fef0843d93523827562f96a6ccd939dfa43ad1dd70dcb8064c40a4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bb749fce340952ed57a7055edbec4c7a0aec9b2623ab5c41997eb4b013287997
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fb4ab93def093fcefdcbafe1055941c02bb109290fffb9cd9012d549aed480b8
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d2ddbbea9b30242eedb334f9729dc9f9b31c9c0496009a474b407393b383ef53
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c362abc58ac4579ff417824ce620962ac57bc344b34fe8f51d21b35ef54da36d
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/25b05f670144f166a485a1d0ac37faca672b36642cf1647d846010d6fe9cabb5>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/14278813524c762255aeba149e7d7134ddecfbb43e7d56910731bd4e13e34f39>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ce5950d88624248728b62bb587d934da5aee55f5fd5a9d3f569b3a1310390395
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/99da98a7a0087d3429b084ebfc4eb5d488c593790d4d5af7253982a2e21a6a5f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0916618d3560fe5a168ef536c25ffaddb15ef6ce43105d3ed20df38615803c77>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d7d9ef5babd2876ad492a71c2019f02cf90c813c00befcf3682ba49186d0f4b1
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/3b1e0143755729396654f651bfed689681274839c427f9598e930d816fb7a1c8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e84ba36959d82fc95bb17b25d2e70c135d8805737ba27bab572af670a2768338
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dbf74e8b71e474626b7a7566e6b74db3a73790e8b991a385d404e2267378635e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c7ff21a1a6c315ca5aec2b136ffcf0d9d285dd37a1d5b10d8d134bb714e8d774
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/304af9edc6185856c8b005c8d33276581b84b2c90cb2a48a0584e3802b7a9813>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/99ed6eee81a7aca47517cbffb46eaba38f3987eeb4ad32c020898644769eb615>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/71d2d00fdfc37c325895247f203ff4e4ed04cdb756413f5837d64854cc91f7c6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d82b46992186c404b09e13b47502a8ab420c8f72316f1819847b1be44ba6314e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6377f53f54990033c90de6101e263f4d9e41eb7c3e4f70dec48caccefc253760>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4adb22348ac4f9e8aa3872c9366df56df12fcb49a854eac06b4c6ab3625bb75f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b2ee8ae754844119d83712a384587b6086358c0673645a27bca3a66e845bce84
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e40c7c891fb462d2128235f88fede078846d942da5688e4f9cdfb5bb04844d84
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6cec176758a515b339ebca3b863b8f2b7caf7da58d329ebceee830ab6518bd86>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f881bb13d3a1ae27056d085fc041792beb3b4b3d1adf1ee3399a7184b71f6863
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/73840d393bd94828f0903e8357c7f328d4bf4b8fbd63adbfa443e784f056a589>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3e3d8146912fb57b6f7c4c665051351b6dd1a92730f363a17bddabe58bcdeb51>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9574bd4a68b1f9243f10b6e5e5c973f4e957c96cd15f57057d2966036fb1a7fd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/78ea1cc22fb4b7760f81755a9a6b0de8daf21268c91ff44bdbec308d514cb88c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6adc5e4321b234c5e026c9b785435c791733fe13655cb3dad402af6b73534516>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5eaaceb01cc2a6bc418d5fcdc6c855bdfe1d1fcbc8abf8bb9cfcea76edbc8936>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/2fb596ee22eb20999478e63cfb8f270ab00e4336e34442c031471293ca6f92e8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/92349192bc0054f415dc7dddabcd0effd189279fb0e7a0e2b9ab8b1aa8bf73ee>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bd74ee38a4b1e296821a11729c1f704cf439576c7ab2c910c95b067cf183d923
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/20b0849eb27533844f4f6c7acb3b8a5bee02a6d2dd5abbc74e07dcfb720716a2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7aa957d6377d45bf9e2a1dbaf7524d01b1999cf0cc5bc8c4f4a2380e13ef096e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3be4b70020a4e13d92d67de7e0624d365cf0909ca69eeedf6f95b0690c96f076>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1ed8e751e664569fe2792f523f234e66bdc42d9c01736d850ae59e1b2177d70b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/243e6582a03e891c3a30a3e5db7552c83e703a609f82e1c5db8844a7ad1c8924>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/514bd3d6ba551d4b2a7e866c7dafd65e371acd75240dc92610590c5804c641df>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/479540ea9de26a669c2c7e6cf5c98a2102c1771c48f63808e0e9b41db24dd575>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8c1b2274fccbaac94935cb2ae499430bddc052c3982a425a77c454cb615dea2d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a4509bc9057f893f626626a7eadd0c713eea564c9c948efdafdfae9a1c153771
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/856cbc8af3fbe7390d43420e249c288596e87fbc069c601751d5c5fcd52c543b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0f8e458aac514d1966ff7594b23fe784dba93ccff5d63fdfa279879eb007233a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c0b6b5cf198cd939251dff8ed052177cfff245074c6b8d43394c8c97f7b6e945
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/416aada66520f1b6f4eb79177cefa7c5815bfb85fd455431c1ef91fd333769fd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c94741a612946db4bffa00439a515a831c7d4de0d09d79538af2a1dd781500ca
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/69af2347b1d0a9a39dbcf0ea4d94b9eaa15edb0c7d2dba56bbd9c39ab1c80e9f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8fd72c4cd5f095c508af05e3406aa63114279e8bde54e9f5b83a59c7794dac72>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/48fc71248bff17e9a5ca8f2c5c95d38ea551084b82e944cf7121749555ea00c9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/476ddecbaf169d4c9af3ca8ed6725f4efebdfdb9647fe82ec4406496c6e930d9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/571b85dc585067ac92f9de90133e747c75f3f7e7948087ae193583b9f0fe1141>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/484b4d65dee04db442889741026527199e484ad1249a9a96401b45718d6d497b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/763adc09114dd8d54a1c8bfabeaec5e5ce543d858c3dff057a1c39f9103249a0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/665f6a3b8e4ad7766a1be93578b5d8b6312afa8600c1301388225880fe4eca53>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/985774e5593009ffa08804ffad482f0dee8490f1cdfde072116cd60e4528892e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cf8131ac6fcc41224b895fde6e18def464a16012f05d3c078da2637e0f1674ee
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bab5de8f12aa24ded31c67cc00b626705d1336a63f5711c1c70a8438daa6da1b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6093f33e8eacb798481b1f826416eaf310552e9568e74804f59c69dada2187e4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3b6163727a5930106e631885999aa8e1dbd24eaf1931367b7f38123a89f14f10>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c2c19bec2f337e69a4c9838eacd88041734db523df4f7534cf407c9d380b64b8
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6a56d8c050b6c2a76912c5f6ec3859b939de6d990815f35403e5be41a7703a44>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f6b131de5e40a0dfd4fc93fedf3b95c9bf156ece718b87fe00469dea2564b3fb
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/6463c55877def582f642cb5b3b4a7eab60d8d8dd9779fc45d87e4c8aa5d9a07e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8152e68420f560b8493d6c555a5bd4186903dc341028bb9855af6c44a9464fea>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d8f7f1849303f3bd250d476ee5b44456d42b4d2f79f8f72b0be754484cb5fda4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/696a100b72d304a89de34ac2f10c9ebbfc82268297f201feca5d60b51c8b883a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d3000e1841d968dd70d4534bf216699d830d146ccc1f88b902b0793caad9daf2
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/19537690173d82d774bf34abaa07f3b1af78139014e53aa8f172a0a558bc5e09>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a10d7dc2599e3ab6854fc83d1023224eda8cfbc62017d4a1a82bedef7a03b8e4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3f2f378a666a52e74cb283fa75718e27d7f3adbf16ffcab02dac203a9f756721>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/93bf61e0c1a48a58c1f6af804e087221de46fc492b30e3a7194b0b098356ab82>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/17e71437ad9e1abbfd416b7bcb1485c0e6e21ac4f65f2a1584eb0985e246b1c9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0efaaec80a4ad0328aebadee1ad36a787adff5e31490795ea411fb3644be7f60>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/32ff6774dcd0547c842f7b065f7b1f9441fba0ea2b2586700a0426795787b2f5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/23bb41cfe7b4cb3af101ef96bf9ef0466d19997c0e100123722371d369d580b1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f39eb137cb5c9195f92928522bbbf0d104fb54be6eb0c9c62a24d16b88b44272
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a9e63c13a602de3cc5463cc81eee0b8d80d14a1846d1deb82b3a2d4e7efc96af
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/80c5a6a8789862c171c8d33ae28cb0649b4a0186114eb49ed36dc28ea515604b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c73ee91f068da28ed1f16fb057f38808e7c0d29f4c5b8b9d7b2eec235ed4d5a4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d2d0cd89d307fb651e2d0d064a89134dbc2f26b0ffacd92d2d71e9683468a206
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7269d3607a761c9ce0e226e0b7ea5687324230b65a568d48c81a7acba53998fd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4968b47120d51c329a12c6bd6742ab220cbef8f6720da3ad8e6a499150a1168d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:da17a1c564c4f0aecbe800efaedcee7428e80c127b4a1bc829519b375ad20707
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bfdf2304f758f547ffb7c7afd4e6358290778642104f73910eadb0fb103152fe
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/670db1d66c0de3b931962e1044033ccfa9d6e3023aa9828a5f252c3bc69bd32c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4fd07fa6c794ef12a12c17976570c2bae5fe62dcc373a09032276397ae153f04>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b942231860865ab0c4108651b117f69a755a04186df97e767707e5d95955ebbd
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bc1d9bf8b47dad5cc29db38c5510f1c91399302b27e928719ac1286637406f25
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b47cda1a1458dc4935e118b6fffbdfbc55eba2659fc9321c61be0de63b5a27e3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c5dbb08e35e2d090a05d119fef4cc161b5ee1f322698cb8ea3c8c6643a521cf2
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e9e0287a3a974fba665e2649242a3607b8db35ca22085baf9ec26972b6e6a86c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6af55cecaea3621f53bb32417a36ed6e3d41b2aa5b9f6d62ab3d80cc8ec11539>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:be278471a2a318edba32e7ac4294c0eafbe4c8077a34dcbb9c2e43211d4a78a6
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/71e6c6f58d20f6db457245a70394f2d63f601a32f8ccbc7e443e98f8d06b0b0e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0584f1096c6eb744a680d13e4974ff85744ec9aa163e31833acaa694c8c9c6c8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c69192b973a3ca11531b9657b3ee20aa6688fa33ea1ef1392310fec751980ab2
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/6d323b27377e803eccb4261e8014f5198bba924b7ec3d7d7fa2d2a3a41f7e0f2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5db8cd4f01b90c3dfc31f5d2b5e931cfdd9116a779790ee55cb71cd314c5a4bb>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7db7a009ab84e4d98e08ec4673b94605584f65ae5ed7a1d8decb23fb990ff73f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/28346950e285b8b816133fece5ac9408097c3f190c7f32573cf0c640d6c34b1a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a1f8ddebe40f6a09270fbe460e71ebb7adda7b1ac2e5c4ccb3fd6e9dda2162b6
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/290c4b53b407dcb12457bd32c9c33e521f9a43e8743a64b02294c72d114ec6b7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/764a0c6bbc866153ae70cf75d745b9477fa010567246cfe6683b7bb8aec541b4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ca02bb76e04d7d3ac3282e39ec861a89f8a8c6c7e0d907373953fa8001c9c35b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/92fd2a12bdcc24f8e6ef34de765d54b3d7a0412b69c0877836cbe3098a5caf57>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f0cc06aca0893bc875d3254bf753f2357f67f2895871347a0dd05628b0ce77c2
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7004c5cca97f47f3ea5fd5d011983bed0257432c4dd317c4ebdf1f1d7035890a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d408e63f6ebbdfb20dbc63f8f8a4f91f2fe4eb23fa2496f9ca102ec583e9e022
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/955a75560dd7c57fb9b882b0e92826ab06d77f1a4fc2722b4421389d47a247f3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/72af5d601b193f4fcf18154d643d89481082ecd3eff61720f1cf118057666ac5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f923867abb64ec787e987ad25b3bae8bcf38dce127e3a664ad18b30e18d70986
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4ff28976ce6eb2a8d6bd19346f5b4de202c53bc5b33904205c8cc580877e4769>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/931a2bf4f5c461d8c3636b446fa642693d4535d865d3af068e87d25ddc93374e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d03795d069b5de6a386ad04bdb0970ef079eaac1be473414bcb63a6c9eaed4d0
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5d814bf5ab1e7ef33db393cb938315910c262743afed3a464e93c1aa25f12e20>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:af8969752f6b28c66b6bc402d7987fa38774901ac72b95c5cb7976570487c3c9
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/7c44225c68f7535a603d3a0a0c57a6424e8baa9fd066b6b9baa636d0facddb72>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8620c62b9e51d2275c98cb724ce4b6784b432db8e1e0376ac70cbda098ea0d0a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d8247b68bb62c768c36308fbd7203c58038e249b8363da29d223aa6cd97cf242
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b4ff2bb483e5a18fed7b115a2da7af8447e1a3bec4283fb5cf480810608a1e76
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/929c049597e4961ea84051927af6be67062da4fc8ed9b755fc33b1597b8cdc7c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4fb8eb24aa9d5561f3cd7b502715fc758f41b71aafa13b872ee8aeb1d027dbe9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8da71bf3f06102d4c2e45daa597622ffd1c13ca150ddd12f6258e02855cdaeb5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a863212dae496f3c67044c214843841e636f373fb1c97a46fef3ef82d77ac925
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:be8c097326db7ba0e0e7c81b832da8b4cdeabe22b515494753dd95d33d9ea295
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/933e3d37deb3e75dba5869d264132550be0f8e2cd08ee71556b9dc6860279257>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/66374f1f46137c3240ba0690b24056a014f9ad5f36ae81e10bc14ad5a6305089>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:f0326d3687d05c2e41ddbfaee635ce7ecb00eddc81454e58eb5fc8c66f511629
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3eb8c9fae32d02359dcd7b22e2a74e67a5b48388df31ad819c27c688fedd10b0>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:d90c540e25805c2ba9efc77ca016e4f24102c44496f9590a3a5c769bd6dffa74
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1b17382556917a15828249872bc4f913a24f7656cd5722be270f0e31b9ff0c06>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/99a87e5fe755c1fbb0b7f5763c08e95561a02a358dd7dd0851d35496bec98203>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/52cc723a-9717-496d-9897-c6774cf124e4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/70628fa6e628db4151087aff35bab9b21d2b3701ce3f59f133128daf0c9d14ef>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3b337ebeb02ede5e152c952e2f24aa1bff3ebbb6afb968a647cb05efe72c0237>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dac6ed961e62f29e2706c8213c6c5ee28d07bb719e564bcd47157499561e613b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8d7de878-db13-4fe1-8d74-bb8c9a690d90>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/59eaecae469f80eccaf6d36a165927eb8ee8749b9866ab1730e6b1ba45dfaaa7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/36f1c660b51e5809170f17ce6bf420a9ad7bf596f049d0d2f2c638f107e8c509>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5a8f9c6bde6c6b01bee07d9dbed16a8b685851865d5083edbf617a4dbd2e51ce>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f8ad83ae8d0d96983b5bddb3c2cb768323b4f5103d95c111f6143c9109034aab
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/94433cd9ac2dd4ef0ccda4e07f35217fb6531adbb80d8382915f89f585d00890>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/47857958-7d00-47e0-ae83-00d914eca93f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f08dca136aca8cfd86913c6e452ca3b763d618b52aec02f8864443942c50277a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ba4d960fe3e01984e15fd0b141028bab8f2b9b240bf1e5ab639ba0d7fe4dc522
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:af76592773d5172af4a57454ea5c3d94578379048cd7c37a4da016a07a91bb54
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c5b139c66d86282381b3eb0ae4da68252d6eaf974e310fa5d200601b7cb69070
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bcf3f79bcb96133312dbdc63dd157caabd3329358ed4440a03ce6d6fc6af09d2
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e39bc997aa6dd9f240277735efd745b6a0422614d2b36cf01825c86b1b91a9ee
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:dfd76f1550853dc2b4bc8d763c7b378c8c8c81588dd4ba3e0ef05cfd0a456927
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/995409aaafd41e4ad476aafc658669c794b3bd993ace46f08fd799c4d1151ff3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1f1e0b8819cb311774b62e85f5d701fcd0a50410894da331687b66b4ce3e96c5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2d6f7aa09c55d347a56da51c583f762843fca5da4acd824ee2dede879a197a7a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1490ca18f894573f76065dc4fdfa2f9c0bcb00964a6af2e21ff8a81e9f1d1198>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b40be11d4f04a2e0fff76e8feae92471963c063e2d65a68210dab2707ac62726
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8745182191882c1185893960aecc2ed4f91825d7a5ea2e62e9f2d7acca082a5e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/30ffe6401585d30b839b382a730c253255d88403dd5baf70b4a3e60f1bd03cc0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/64670f8facf973e783fc7dcf5bdb8db91d3460f1a54a262f113c2230b3685af7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6e7e9f3e54866ceeafcbee973e2799e4d1cc8c3970f92af29fd2d66d475c2b3b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b45815b052363cc4b1c89eeb8dd6ae4dbf8433883d314b4c1d88c96a8d912212
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/56423901b281897688074e6ce6811a6a33eec4070da7e22c4fae65050d7b712f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7d7122bd82f165e091a36c830d041b59aa48e4be9ea0aa06dc4c67ef381b7505>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a605a770e69d0af2d501614a41b446c76328d2f32165be238458468fbd5f8b88
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/530983bec9d00f1ab745b2eec290d35200c1011c592bd5694782680bf055092b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4f0eb4436c88cf831c35f84e7c34ce32f9ee4e99c5139aff62990e5e531aa1e7>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:c42e0bde83126aaa67ed2c4b3ff5f5b42ae5023075e707c85369345195c79a43
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4e6d15d5c7fd95c996087bb13cdee985f0b550256be745024d5facd1485df284>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d7187635377e73d8cdd7e2743257bf93742a82f700e6839eb12a3e3705ac36c5
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/421187a1c73dac9514080c9eee61d018a1fb93977cf7aa96bff64f35dfd08961>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dcacdef6115b1c15bbaf8559ad4fbc3b694a12af37c178ac54227a630d2ead34
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6025a5d1ca2262a784f002edd8ce9ca9073ae3d5ebc6b6b5531f05a29e9250af>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4411539b345d3b7ffa3f9ac54fce0fc381e579b999c46cb11c7d9af03aa04a79>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/71f6925a4b895c2a91dce039c87d227809edcda82963714814141b1e41631b08>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/61c1066c653e5450f2b0a25baeaf60a14a8df400fc421caca07014b0efb55c96>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2ac1bb2a7d7bbd98e2e7a24be2c67e42171788a71c2436a33060626593bb2f78>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/95e51e4c874a9db9ab6fef81453b1d64531c4c5daaff47b24d266e3ac032d759>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/319016d52cb54b416721b0c5fc74f211fdd4dd576d13a34aa9210759401dc7f2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8662dc060c121e9d69101062f67daeef8370d38bfe86533752b9e54190dd0e2f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/87548df6451c56b75e1064613f01fa92bb0c1d9b1e0d9019336fabd39e54ace0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/75b2e9d02e7790b6c0a23a3885df7e3069723b219091025dddd67ef84ff24c87>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a0b451f349f1609834f2236ed8149e4f254e9aae1a897c531a99b9b0bbac0899
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/43d5a7c66986ee2e88090b3988ea0179ad4abf5bbfb8864fc44012aa181d0e4d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9b93ff5308590c7d03c97c3b892910f912e695ad45c82465934996fb04dac859>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8fb90f367f105c14f37a7062d6732696dc2efc292f87fd5045548a0da407dbe4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/46a7ee2627bf51959f9a72fdb6f5aec942f5e07484c1bfe7da2fb8a74c830326>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:c648ea5d12626ee3364a02debb223908a71e68f53d69a7a7136585b58a083e77
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/18eb574437cc9fa5af24990f495aaed7af868d33341faf60cffa2ee0e57dc914>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cb2a6e0a490ee881ddd0d9ded7f2b3d1dc2df7e57a19d014caac054bfa355f5a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/05099fa1f6524b8b994d86f61549455d2c00b2a956d5308683ac2d1f810fc729>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c1c28cd9e31c25100374482b71b951d5be9b849454b1bd7e1a5158a589bda5de
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c6ce52f7a484e12c7f385f1116766fa9a8d1a1798e4e265a77a8881a2bda9b60
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/169b6bfa2d8ee340f266af26d1a6055182214082dca720b8817d3893692f3068>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f8b1c302857125ca3cb8cb7a7305ba2e00a19452bb4fb99df1d9b081302b9da9
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7650801ef7de6598dbb2d45bb2caa877408defcc1337fa698520a25b85a300da>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a510e5ebd5798668f45080e36762539bd3bc5d5b5f05c5e1e7ecaf27e481ad31
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5a7f00816df0382694760a86baf23bb6c72a7ab5de0eb7f6db8c38a24b9c9aba>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d9267014daa2764a9edd3b176678b56f57474ffe162363795690e5c684c6eab1
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b4277a54dbd53cd3928c139c916eb58b03c7196c97c8d30f21b52200cb5156b9
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4c1ddb45485a5dc672a57e8347318cf5d60a16fc2e527ad055d3f69654e11b5a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a3bd0845853278f478f90b14436d3efa99e73249a84d462f0ddc2e5b6e37a156
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/4a617484e231a6bde8dc15060a02642cf1730faa9c0e1dce0b7e6e29985deb04>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/53eb88088ce2822bcef97df5f71154045e113b750c6b97b29793a29c4f0ac7b4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/57b1646f-bf4c-4dc4-8bc9-6ec8a6486018>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c8f33e80-6f19-4ba1-a758-9d85f42d28d4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d59bf99ac29e71796ad7bdfe68cf74709c63721691d9680e0ea7636070f7513c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/764278b3ceac360476b418c108d1b022b6e0cc8fb676f3f6b6b9faf78a2375ba>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bc50bb1ff28814ab2441a22fe111d895742098d8a61d7f648efbd9ffd48446ed
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1d2b18c49b345b619afdaaae22a13bf31156ef06417399fd59bbc321f15d228b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0d2e643f4635d2b4d2fc75241a1624013b274c7ffbe8f8a5f36f2bf250336863>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/19a90656ebde5754d524ca8a17d06b857a6392b0b3db57dd24f899a1b71eda7d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d93451bf-e89a-4528-80f3-f0a1c19361a8
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a277d61f41cf0025df3e51df800c9551a27c80e2515c32aabbbbbc2c818852eb
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e971816acb021c37576835e6a96922442628956fd029d885fd849c9f07414469
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/788f5e9af7c2e5e158bb9b72d7cababff6d4a871c5b63f346c8fcedefed33905>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/217bea3a017fecc9d35b545c8142d993094407d81b43582a9be78f9d11b26256>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/215d1409dda860a1ce4f39f1f6c082c5662620d9d29de456f4242fb6cc6df0b5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1db0e6fb09e60db1e8534b20c69abb03584870612717a454937717be9b7fd019>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1d3478c91c85f0fbd40a684bbdb94e74f255a22634f4fc32f7bb83ef89df54e9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1c2c5d490c68ea5a258f5a5f9c5d88c55818d0e0ebbe99ccb6547495cd26fc0c>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/1a852ee5e11b5b7c989135cf0a43109cd903ce05b113041337c82d7cb3b68300>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/1a67f66df5dbda2402ae9ab41597032d10dd5980d5d0d3785c1c2afebfeaac07>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/19c1183ad20b9b4023da2eb7d1ab3eb5dda64558e050c8198abf9714463362ff>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/19ac0fa207989c27c3391e327aee16435475292296f010867945bf2987f95477>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/19877d8078eeedf77e4501754683691c516b007c67a650f3c052845328d60577>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/19783ae65bf47223c84e052a8a1afa41e534284b21648d844686eee4b0650b2c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/195d911f1417b20a4b715b1a54e8ae6e92b9a23cde908f2fb03a0081910d8fce>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/18014ccee1691f34adb3e438abb02982dc9bbce680063a8effdb213992f3b4cd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/178c9c989f42cecdbdfcb7150e9ada7869af574d20562a5f0008fef006c4bfcd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/165a9a64a6b84a278806b11c3f760f48198990168f591cf7a7462beb0f2cb16b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/12b3670c672298b9f906f60433ab945a8c8cd2ef8e4b5f922d1fb284da18cd73>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/123e25f3315abbe9c60cc2334d59392342a51cc7ad74ce41771ec2f3558dfe6c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/11feae29e6178a2b58ac73bb639360d58248e3e438f2201f219b95b58c6b4ef4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/11f2dbf4e7a82e0211805fe7f2d4fe826f1ec6e7a3487787fd06fb5bf7c182b0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0f804773227064c4d1402e260573706c6b5d66525e72184070f65686d58174e8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0e471e446b90ff76880b49e202f6712cbe8db11ec52a4763853e438f7446a21c>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/0d43a685df6082a3c14ed4ac74f9566ae09c679e1df5aa720ef6cda3e37bb72c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/09ba2fe670a607d3351a0e60cbd79f9e1a04992d576ccf33e842c80e669da996>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0e951dd15341d38413bf809f16ef5f1bd163092001ac04ce78a4de5b5e9cdd37>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0d30036b943b9b9c3ef70c7c0e59a2325fbe2c455021ddb07bee427f73efcef8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0cfc443c59ad06e1292b9805d967f181b989913a1ccc3e3f50a4dd8ca16bc772>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/0964427f9f2e113607681e5c25bf744a41bc412a94e1c0acc784a48d79441df6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/08b6bdc2c34dacae28168cf967ef2e13384f032a147ddaea7f1145eff4f0d161>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/08b125860dd7716256dd35ba2e38a009206555f29adc44642c655450a471ebef>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0610b306e95fae751dc07050565e987f31ba06420863bc44616b2e05452d8822>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0594a740b99274c7347f3492ae4d05f9b05d057a1cbad30683634296e189cc38>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/05354d6fcc016d06f988a0e044fb160be7573550c11fe414b3c011961150a686>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/11410c82b479306316ccaa6d18f695bf276b71e3dcdb95af5df9530b3125aecd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/79a8b906745ef60f03fe153912adda80c530ef733ee0ddb4e30602e2d8611159>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7800a6f5e9c3f646e274b280703730ed5e83fe0cba1f0d6c7fb18141337fe781>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/77e7c982b4c1f0f387e91d9388ffe0646cfb260ffd4c3684a696acba744dc194>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/77a7547387a6dee1728200f54a4d54756c953fe5a702a2e9fe2008b217ff21a5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/77a07ee1348f6ef3b81ab685368d02c33812d92364e667f68fcdd073b050d949>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/77801115dec7f63400134c21d897a41bddb775eb438d81b354ad18fb6d7ab956>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/74df7ba8b29a0d1481610e886110d971ee66e43ec3a586e1a873c241d1ce9e48>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/73777b2512fc25f16554612a13b0de2265a56540a5ea6665bf69a8b5a805569a>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/7271a57b8249b4dd3175f50ea96c66ff536eff057c6bc0acfe40281e2a91ddc2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6cdf24341364ad76bcff1bc07f1ec33591bd8ae0f6814a3694f8a00b61d2fc67>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/694889b358d92509c19b7affa12772c9039d8e1d4c580792e0e2d3139ade5323>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/68cf1a248013d8921af92322a077e2c74988889defdfea0cc0d467eddf3baf1f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/68ad1301fbb5f209b4ef0fe2b11e77c7bea6011f5e28f8f6875597a7b08f0f1e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/67d72f2e178c4adbd0567865d611248403aecae0e505fbb30d3c932a634c0d2a>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/63b99975033f43bdd2278ea9370ff1a4dbca4f8b69fa44dd6ed33a231511540d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/636ab432c60704682de8047c77c465324b4514ed0abf578aa08f1638c6465d3d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6290ea6bdd9ae31dc8821e5ea96e42bba1a49ddefbaad13a9d83888c814225bc>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/85a1c6094c7ae59bd443138cb15d2430f45ffacc191ba56bdbf41bcddd94bfee>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/851f0fa90c8c44a593ac497b3fbc01a4a1147172269c4201030c6ff3751a8945>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/824d533ebf12d6c2fe9633c8c72c47712858773995e699424cf19687c8f0558c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/81083789b63917e32ab90ef1a45adf893f370ee38da2e0542e5c035db4f60794>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/80a9ab8eb46716ab23c597d13313ce24b17884ffcbdf00d216b877d57a52ade4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/805a977a29725d94f50bf7f0d91a0de1a727c4eec88940e90035f71c6c9b1655>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7ee8a7de1eefcef48b5ef658f37fadbd7eedd5b1b4b21092a217f222ee230970>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7e526f7f2d12f55a06620b512401826b6855ed478ff0693e04fba59cabba3c4d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7e1c2aad6b18fb6dc34790ece7faa1fbca3c56662cc62b953adc2b6755aa9da6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7ddda00fc45a0994092bc26f30d97352b7586676438d5557b3f5cc336daab063>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/7d9030b3d27cad32b374729309feba35e1ccd711baf76b46e8d6b190802b196e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7cb2089a8c6746d514711908abfd38414a2b01f6ad9a83f28be2e835888b3da7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7cab1a9c6f5dc798164f1c6812fc790e5279a8fe7800a2e8b7a159c581c866f1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7bfe1dbff2a9a090a230e7a10d1ebce3870abfde07596b851c76223719c13f17>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7bf86323fee74ff43646d2a835408b15802b2e8c7334cbac3a4a6f09936d2adf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7bb57aedcc889acea426829ed00098593f424f895745b24791dcf7efaeb8fd29>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/7b6bbae823b20191525038cd52089d22128163fb3c7f851ce56149938628d941>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7b68e778b23e17a95ba8d100c5ee6f7105e892ff27103f735dad6ed498456204>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5ac1b2b79334a5e0cb44625c86f6037543d669dc420650dc389f31d4524bdc4b>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/55e0bbafe53638319a0194d6bd531551457e5e005499dd34780a273efb943bdb>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/55b7e0412b8a8256b321f5e24b3e7c289f91aba5217268697bfdc4fc7ee2f853>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/55032ecb683145685c3b44cc0ca8da2fda8da8ac53488a546748df15559c5b08>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/4dcf2bcd66256073292a85e63e5b443974e1b938e60ac0e04fd1f77de1db3dfc>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/48d8f4d820130b9ea112007060cb8c0e6fd020493f661d8667405d825201622f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/473b0c2ed8012080fc935765882bc7a09f041fe1edb1ef8f1a12b0409f51c019>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4725d1507f200d6efabb38b642019ee7b506a22e84112c5b86cb7618369d998b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/46aa6cf0a8e1db3b7a1b010853d762b0c971c26c6e111329edc236d204c9672f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/407bd6f1567ef56e51cbd0242cc6ebaf7608ec3bbb2bc2614b2bee95c7f77a88>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/622fa725ba8455b01817c8e48974edeab56607018fce5c1cb3694306d3e7005c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5dab8a7b0656aaf0db13044fcafc0088f9f0b7776c294a6e9abfdbf7420effae>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5ba4a42bd459dda75ce452a253ddc09547174265456ad1e3f9389a3ff139a1f9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5862e658553517377cbb93414fab16bffa3f79c86e24efc0217f19ae0d328a69>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5567394c206a8da9fe1e8ab4dc1d043eabdb5915ecf3d06a9495dc64cc3c691e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/53fefc09ccb63625eda802c01cf32df7fe8a14a14f020a89a08e68dc49d43e31>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/520ae455030cb427fa5dead38ba62d2975fcf2d0f695d365cf9e84b5b5b5b73e>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/507182a9d6532733ac375988f8288bd1f5fdc2cfb1bee374bb6f5046bf307d4d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/505e727b7b078c3eb9a05f754d834fca559d28cb3cdb02d5e4cdb3be300ea699>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4ffd00c0ba7ceab20db24832a4b9963112ed66914dcca05f3e5dc8b8b9d4479d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4f4fb74c49f5d68b4d2e4875bc7daf7f25a565748f89b49e37e41d12ff474f00>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/4bb83a0635b69132a4de91667c0a30f228720bda01584b3a01c4cf7ddfc12664>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/479036ca47b011e16fefafbe4d3512a44c564804dc26d331ce4dcbe0fa3366d2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/477e468496131b7d35f145b0361bca5c2cad577fd9ec27d385d703942dc944d0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/46616861cfaae13b550a36ae5c05187638df0873024f13043d3f40f24cabf4e6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/44b84fe12963c437a7d29d16be7b6692d5bb0d00cec58175bd7239286af86a1b>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/41e3bb71cb1fe2763a64ce47ee758fbeb532fbd4348281f34a86a5f88dd71980>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/414f3538e482d3c1c21382ca22de18998ca1d3f5b517ced85946ecf90143149c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3efcad40be18e793d070f78a44f2e63bc105778d6c8c4edc4bfeb5a87f06554c>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/3efb7cb7fad9f61917093d42513c8a7153120906e9701b08e3560c8f109e64c1>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/3e0d98f490e53b1c91990f2ef2d132a371e4e13de9bb83cc239e8528c349a7db>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3b2c2151632d84c55dd93372a4e91a7493455a7f77a90fa2066fc618411d0ed6>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e10b5c6c27e642c4f6ae8b1aa623b1a696318483629e5edbea343ba20038d94c
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e06ce64825e386178b350aa6b2fa869c70ad39aa99ddb3ca2a73d6b103e91161
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:ddba3bc13626ffd574c70b96f9aabc8376518b542d2b5bb6a69ba0f9ea3a8232
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dbfedd56289924d8a7cc26a5aada392281547e053a10c0678238fc08a219fb6e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:db5adb1e2e7ad0e33725b83edda44f9b4638e328a1534a1b4eef2683d337975a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:db43321c949a4c8cba10b65a71e6144b56ed0eedc3b537e3cfb446c5655b6aab
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:db299add14cc24e7a99ce4eb51015f32925690fb9816962e500f3341842ef6fa
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:db020abeb967dbe24b54dcf218bf57ffdbd769bd9e538f0edfbb24138df7e5ae
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:daf6a1611966a18c73621d826d821e35171ffd8bf0bec74ba4ddc6a214b1b7c6
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:daf17a4b6bf9a734631a90db5f36dfc0a95d832c25ee53bfc4ccbd43cca5d8d9
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:da737a74e5094054c3bb3ef077839626a02eb79d148e15cfeee18e10c18ba55a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d9196423b3657e5484236c769737573e4574e223eaccde6a7b7207d632a6a669
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d8d1b52a9170168ad481f2495652e1b9753aea23385f79710abd86549f1373fa
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d847f2f345c5e58882e0e468c31de8868e71a73f4cbfa63823de17da3c7f1942
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d803e24fee88bed6f28f45f869f7469ce77f3f905c033caa6d7526a743f3094e
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:d6fe7204ffe4c6c227156eb34caddcd860f911cc98728f9593d9cd7d28d3161d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d5eddbb558ba24514f315f3a0fb6c2c35dff17c68ec93a1dd7e0d7efe73d77b7
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d5d6693850ba1a749739c4574e7c75a98820629fdbbbbb143b7a4f7c279247ea
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d4f4ed3b439b409b10736d19fab7f2c27e20acdea7b3ae0c49bbe1d67da07501
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d39a7017044dcf082194095e3b3ec72de112bd47528e32125c697be1aa3c10cd
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:d1e07ba478df68aa0d517bcd253f31c78a5baedff3600d5e0d3bd774d6434863
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cdcd4403-d4cd-4400-80a3-9882d79933f4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e53d6b0b72d98809655e6623a0c25c0f6ba815d20dafb5c11838b06c61cae2b1
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e4f4aa293734f92302439270cf98805e4b617088cb19144b558db2dff087d886
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e39d8bf95a03ade08ef25a79ebc050abfc81a69731f1de66fe6d031d27135aac
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e23cb5929d99c7633348f71af1bf11ab5b8fa3649e34d4e0967a429ee6437bd1
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:cd2f6f0b4e93922ab12f945b93a9c28145c2389cf67c16342798d3ed71375b2c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ccdae84a88350f38b8244305ba8d13b4a50951f3a6cb1da2387405b92037828b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cc703206c37a0a9b2511d56046a0e26d53e708fc1347a79f2aa9676e09d5a96f
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:c9fd02221ff5b1f0e671b6a155bef39f9aa6232e351eb4f0f00239f677d51643
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:c8181e769c264e365309a9d8fc6e945293477400147856719c5d42807a7f1643
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c3d16711b63bb5afb85caa1ccc071fb4561e2f73d5577e011a0b624693ba5d61
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c36188cb98a1d51e2956ec4682add29d2905e166c8c76733c038a986964e5d82
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bae67c058833fcddb14625a29f0b01d833639661f2ec0b6628e42f058e6cdc7c
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:b79821cd556509a873c31be17e9248f9a073c04048376e742f10ed02dcd85ff6
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b585fb63a6ebc301c4c3c2f5f45ae92682622d70330128f160fcd1c4481d1d3f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b20f25782d859216abfc3bbef8e9d09342a1ab967adc85859ad9faff75a638d3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b1cfcdebeee024e79b381d90a492a8eda63991d8e45c1f16330d78246194df6c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b178be2850c9c13af987fe528f49d73be23f079818b8fe36f55d1524f17c70af
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b090b8f36088e8d98a4d1f9ebf43191cefa2b9f84387aa4821835a7b233d2579
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:aec8cabce7f06f1db4501cfd05deaebcaf4a418578f59f107f06bca7d4825b40
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ad9947bf12614a73120ae8e8653f04b26960a883e6149ebe41f47fd45da53a86
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:ca36d344f695ee5ab2b21659db5d54a68b55e7c36d5ff1c3669793c241746d94
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:c8d171d9735146131fcb9e2ad7f4e271585b0bf68f7a43d8873b6848576d13a1
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c7d15b793e42f0024e56ae7a89d02f8d6f491ec42cd2ece4c856ee24b154559d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c7778ecc532ee037ab821de348f7c6d98ed5b2401abce2e7da64687290c08962
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c74e71fb4ccf2e143731873471a890b87076a9b1dcc470b937b339d7c191fce4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c747c462297c0fd1d31076b8f5b20e23aa3309ccb0f5b0b072097aa7612950e9
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c5726151c11e3ec6dd94a158ead5e9bd9e4a7307ab76e4f64da20fc526d481aa
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c46ffec7069bc8edf812c7c2ce5af392ddf2b5e6c4ba59e8f02a5a5c976f0312
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c4486571e2cf6a0656e29a47a3f210cf9bf732876320953c5759aef27b639842
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c1fcc0a6c6132cb34dff9ed6e6f361d1587c211ac8ec1ddef409510bf68b724b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c16d166294750ae2c48acae9855a49cd3280a3597c0d8f3257021c68fdede345
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c11ca390da51a65c5e328cd219eb91f5a657bba3d0f47cf995039dbfb1c64105
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bfc36f138e0c7d11757eb321d034cfbffce281679eae93c2bc5df1048aa05789
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:beff71011cde3ac0ee0d94b592462be141cc9f0deb5c6ea996ea191bf79ae2fe
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bb9a9db9c00189c27a851f0b772772675cba77e2463ab734477d00e4294db5df
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:b7abada470cd56a64d67b5450b35c3e96c07ce5d752d6207d4886ccc8f4852ff
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b6fb86dcca01c89d6787801c958d6b8551f3755ec6f1c35bb97c0cf37b9ddc2c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b5aee7f43fc9c5d0df74e2cbb9214c03c425cf026b1fd77dd1e3b08e5fc7f875
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b3e202bf5ab9d30f1928f7a1ea8911c60da595819774702eb1745e83c25cf106
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b312420a9e4331da36afd70237db5061825cacadcdaa68e6ad0f1ea8a9426f77
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b2fdc615ffb131e53a200e14c74ac92d4ed6dac176e3e6ea2c79d227835077c9
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b0409ea840727463f3ddc6f536a730a6485c194f33ed8c4572fbb7d60cca1538
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ade6a3d0e031660258649f141b8f17015da01557581f74122147c738af83b0c4
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:aca61374bd3a42658f92cdf9cbabc9640c64c4fbf738cb56487d633f47fed7be
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ab684e431e916a1b992468633b08a1e8c94fbcb3cef9f3b74d1115c8dc52e6c3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a878530daa55568d730b565e77c726d4255374b19bd16947dd074e1ff4cb5235
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a75bdf601cf1ef3e0667c176348c1453d8513da729c8c9acf0179a2d610b4622
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a5fced1aa1614b9bace5c896cbec16b63f1e05057c231b1f1f7b07624506fb0b
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a3e6c576223bebf43dcef2cd99192329b1361d2923c3de5a3b7ee425c352e086
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a34622eeec02e47f8dbe029a781d69acf7f07eab119eef7655328f5512aadfdf
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/98293eeb0de606afc2117d476e7106d1ea1372e475ec68aaba875f7dccf771fa>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/981f9ad1586bd002777ad0b8238ffc4335b8b9c875f09d9cf2959a4f46e0f58d>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/96c4a85c6adbd9aaa4973541d63437d993b5e598918d24b904c8725613ab35e4>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8fad1cde3ffaa544cce2049a3fa7428f2a1c154d411bbe6fb697115c488e9821>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8b747c5b4c6da1463f09c552e8ecb825f0bfc489348d649e49e1d3ca11e748d3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/87169437917a785a42f51e726c35fe5c015f0eabb707cef0fb8a8cd7f32664a0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/85a66d8034a338984450701e8afe87aba7d4845205b11b1ca4eea918279df5f7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:abca98258a8436dd7f74c633f0b60c7e50b407a1bb27777c102a1963f8843f8b
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a79dd82a5e400056b3f233fc646850f57918b6173036efa1c3597971cdc6649f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a691d36ff95b67005d30d5fb89594dab69ec7fdbf975ffdcd36ef9bb39efb06d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a65afe7380499a2c24c2d039f2a97493f2f99bc03836de9bb99c2c267676388f
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a62fddadcb0a8fb878c3edbdc71a4eb1e6c419b212d41a8bd589fb1a370eb112
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a3b32431cfbb18905e2c7deeaf9ef7af35cd17c55d053a05ed9cd8fdec550724
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a32dc005ecbc001abd3338cdacb111895d3053b313654136ef1903035c10a53c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a31131dd72b614c89184b331821c10a0f8feb109881a1b164749e9c8941c5e6b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9fdf19f0cfc9e12bd58fc10c4da6e8c6c40e813ec5b9f3bdde92cb00ecd972fe>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9f839b41d7dba917e53c483d35e693b2cefdb89a13a080faa762845af6a9a337>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9e247bdc1cfe10c5b244717144ef8495d27dcc193c7d22e84c9a35d020f6602c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9e2072f69e9c1ecd1af7f65a234f141ef6cfe36eb63b2758d54d1414618188ff>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/9e1a43e3eea9453e9141292a3d28aa82e41b65ec7089208c3bbe2aca902ec640>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9d0e3fc23f4fb9c23cbcc30474a1e518c9725c069255090d46eb58c13d62baef>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9cb5a65d9190da4bb96d0f59882cbcfb34248d354e6bd27101fccba186f4c7b7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/98967d1e1e3dd66ac9e32bd1d536ee8e85c9126cc5fc04354a335d5aabcf9b01>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9893dc25d4b91aef9e2ef6f712e0aac68cdf6f144dbed887c9500e6360df080d>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/97a393c64a3c30e619bc115ab8b2bbe0bd7a83265ebb8960c0f1154b9628d340>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/97028faf77fd95eb5016a13c19f3a3a8ccf97c6c937398ba96976e52d171dbd8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/96d87c4956c98414938dd5fceeb05f65feebf21fbe5918e6d23bc2b58a7fc716>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/95871bddebd4ad93db54cb1b40d41af29f7ce08f0b59698b0540be129a9a3433>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/934917cdce95b7d47219ca88ba5dfaf99d41d1580985a3ff521650c115905da1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/93389f5157ceb037c5e38d7b8119cef632528b870e91e209c033bc2eac220cc1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/90688b32e0808b6ebbb7b36030526750236527e8019414449065f57ea384ce71>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ffec0b97d60ac685f8e95209fdbdee3ba0171511609d109d4252a34fc5bf4160
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fcf7d6ad3f71223a97f2f4abf524b822c6fea9c53484eda15aa3bf812c32abc3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fc38ab482136f9a3193adc71d86945aa40566b43a81767fef0c88ac9cf1ea6d3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fa939498080da2c175719511018d7590f179279a771d69c562f59dbe152338fd
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fa52110c7c3e70feab724980e2d991a97712a1deeeb25b168ef6de7b16de41ae
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fa5170c84d3a72af63744b75ab3c6cc59aa7dbee3f3a27f6e096e67837b85463
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f9f4fd6510bda0602c85a9b7caa1d9595f84fd7a2d528f906c0390c05e341752
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:f911c296878a07632996861f9cf503332c94aa180deae4de32e709af35e92a73
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f85e4d1729aeb88670f5305fb5c373df2072190ead153d6b9364b65b9e0b3a8d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f8087f75763aceb46fe2d103a6801bfa6986fc5b17d84b7b1d47742ae006a159
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f7ec3b8b3f74b7656c1769b7b1ec7641e12fe8fcf64564ce0a204e30df498907
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f783f6897d221c6c0aa78aad7a7a695ce99cbf7177b491143a94f1d1d771e12d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f7618c1aadaf1197f307c4dba1cd505c12330fe77cec0b41eb46fbca1c5b7507
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f5094b8d7f26d69d04ba2c469a09e0c6dc08a78615c9483fd97d6d029e064121
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f4838c2bb548a35f92a6ddcf725676b9f137f3fcb11e6737caa7cab1f1314e27
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f40698297085d1294433361d09855d1b46e3a1752b23dcd01ea68a379684ae45
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f32f26f5ec821f929cac02fa27907f200c08db6edcfd21a3ee81bebad372d43a
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:f2b1910365456f2dd2fafde8cb5e08f5baecb6fc4efa48bcea077f869674429f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f24aa1f46c9e6691189507c822ab315c6743af414822b276baab835f1be889cd
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f057bbcbe2ca3af842e632dc5d150698176ed9e0e08b61b7c8be48add23d639b
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:ee127b8376c6b533ac58c6f59a8e6a5d313d15dbf65b178ca201b4ca39522155
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e722e2a640136f8fca8c8f27aff77b84bcbce3b9d3fe4f9bbd6e9a83223bca30
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ee07affaf869f10517967da1ba7e79151646a1f3621b3cbca591cec2b8c549b7
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e8bd746e2dc3c5a72fe4fb3da0c92803b0728150bdd66e860d6218bc83098941
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e751787ca5ffcb706cd8e5bfd8431298752502467ee54371e9edfc57fc231ab4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e627d30fef872f123d8376799793beb1c05d3aea2dc2670002a81693bc0941f8
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/48de38c2-8aa3-4f38-8942-c143ff8af403>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/251143c6-2094-4ad5-8b54-26cfded0082a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ff7d80dc-ec00-43ac-ac7e-d51694df37ff
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e7692f99-9a36-43e3-af78-b320390318dc
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/677E966229299CC832892A2D>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/682c21df-fe6a-4266-8f97-109e5b5b4ae4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/173816cd-8ab6-45b8-9e98-1b8a71ad7ba0>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/47fe127d-40c9-4598-a651-fca0311d3546>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/42fe138a-47b0-426e-a319-66bbf7927168>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/0f3d264a-dc1e-4a67-b2dc-b16b8aa1320d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/989ffd59-fdc4-4faf-959b-929aadc42f00>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/85594b7a-4637-417e-a8ae-6b77c1988dcd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cc175465-0aa7-4f86-b6c1-fb9e4968def9
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b8228e3a-13ab-40ff-9299-a547b408b296
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:d0125202-c4b1-4372-ba12-d6de58b12660
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/26009b3c-256e-4a6c-aa3f-48e37b5d5c64>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/344ff196-00d6-4d31-8abf-bda1a3c06b23>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fcbcb79b-20d1-4ed0-8ef1-744ca783ab14
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:dc0bae7b-c4b3-4318-a6d5-63da2026a19f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2d7e83eb-ce57-4739-917c-66564653ad63>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8c8fb770-1b84-4d18-8bcc-3ed9440476d5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/68691928-eb23-4cc4-a66a-9deb0a7228ac>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ab64b799-fc73-417a-9fde-ad15da02944e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/923b203c-b8e0-4f20-9076-c2381e0f4294>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c7c5afb0-33b6-4c12-9a91-0313c5e99e09
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/65EB0324E77A4F2289F6B63D>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e2fdd5a7-c67f-4cad-99c5-6a2c5212f9a3
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:fc648151-f691-4d75-a954-b3249a4deb76
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/384b48dc-6860-49b4-a9ef-efa557299950>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/98afbe1f-4e7d-4896-925b-d7324302ce73>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/17d5a7a2-0acc-4e7e-9b1e-22dad779784e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cb0ff1c2-1c8f-41ed-9ca5-4c61ad5fb4f8
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9be5983e-1bbb-4531-8be2-76732d05bcf8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3229b915-2ca5-4994-a4ed-abcd02565589>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9445e442-8be1-439e-9484-a442cad97198>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e2884b3d-d22b-44c9-8856-1817c8c7dc1c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1b4073da-5551-4237-b25f-f535e1d28a2e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c820dcb5-a653-4817-bc1e-70035b8111e7
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6dadef0e-d369-4fb9-944a-5c818c96356e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1275c3ba-7276-4808-97b2-e2fef32f06e0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6c48862d-60d7-45c8-8d84-33c1810503b9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cb1cdcd2-c440-4e56-a6ef-76b1106b0c44
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d632323a-41b5-4267-9d10-14fe9c2c51fd
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1a652a2f-6f09-4084-b53b-7e0ebaf7a09c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/714ca33d-beac-4601-9076-c9dbac387455>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8cc49211-f650-4ea2-a6a8-3c52fde303b9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9d18cfe2-fbb1-42fe-aaec-ad01a7f369a2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e2c5194f-29f6-4095-a4c7-2aa1a1931061
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a99cf0c9-dc4f-45d4-bd79-191b33a4a350
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8f743a1d-b868-42ae-9a30-ca3e167a12a2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8dc7a849-a781-4b9c-844f-406b8914c0e2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d04389f7-73ff-477b-966e-192eadc7492b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a25e2801-113b-4ab4-90b8-0dfdf644dbd4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fae6d983-6464-4be5-8e9a-cbbea01d1c48
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3fa44a3d-6699-41d4-8f98-af7604ede116>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6dd51077-14ca-453e-9c6c-a79af0d6c583>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ccefbec4-7cd6-45a1-8d03-25fbe7aa3873
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:faf9a840-0241-4db1-99a8-a21704d6a414
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1556d59e-1dee-4135-a48b-516d1d0bdd2e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/39b18134-b417-49b5-8d92-efc5a6c14241>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/663489ce-ad84-4e24-a5e3-ae5ae1bc4440>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c67f216e-dd6b-44e8-a2ac-aafcf100282c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/23125c32-d4a6-4ef7-8a23-056ed3e9bcec>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1bcd27f6-8a8b-4666-9ef9-55c139cb4bb4>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/1606f5d9-b418-4bf3-913c-d452b6adba00>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/88fab90c-ee91-46cc-a989-a9e9b554706c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b849b960-7072-4c19-b83a-9ed471b39ddc
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2dd33c78-9cd8-4cad-94a3-18bc3e5daf06>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d4558f27-6ecc-407d-bb4b-f68a1e318dfe
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f6c826d6-45e9-490d-b27f-291accdfd85a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4686f542-0fc1-431b-ab4f-f8e8731ac705>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8b19b2c5-7a60-43c2-9be1-c6ce83de50ba>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f28a2625-6f2b-49f0-9fad-421230b9eba4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d08f6869-938b-429d-972f-0a8527f5781f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e0196970-0144-409c-8f18-a44a6fc97763
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/165b8b9a-0977-46d9-aa1b-a476e4b7449d>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8432525e-3eac-4c6e-9682-1caf37e19227>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/45d2a75a-aaa7-4607-8dad-58de4e2a392e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/677E848329299CC832892A1B>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0aecaf39-7e15-4ea3-be2a-4059e65f0d09>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/20ed2789-2e69-47bf-ab84-64433d59fa3a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2ca642d589b8012fe65bf54df3a87f740acac78624a902ad378dc4ee6c50a848>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2c1fc56876479e83c7b144e98b84174dd10087ae59621204b9d6701d968e8aba>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2bf97f7faebd616265d004a80cce0319a110319197b657d5a0a1a16d81f34ca2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2ba0f1e28168459a963a81784a8404e94268f70b49f99342d50ff421ab8a06c6>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/2977f33873172bdc36e61de8e299af2b70967fe412fed37548d4d7d4499fcae3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/26b729671fff1583d8b0fb1f331e2058b404a106ec4ad6d023e843304f85335a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/25572d6c63bc386d742bbb6ac0d8ddc739dc0599e156c6eac68aca492390840e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/21b4ce7fe62be7ff933d91616b54b79427dd96026626c75ae2a5b660ac90581c>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/3abcf1a2f490ee09c9f0bbc0865ccb6c421dd87b9dd79933465df7095ab30940>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/39e3e46f7cf031133152e763eaa26cab3df81f842f9912a25c69c445f0c428b8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/39e0e2e69be463a4628f87bffe7dc6206aa6daa4a5516fb4ce11907f57d77079>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3964b39eb4f101cf938190f44848ba6bd57b33e6966834f05b652ac1c928235e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/388e4decec9cdc2dc05623b8f5fcc8cb2ba0c7d6d22c91930cf2e83606fca988>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/3648f86dc8200d5a96051a21aa6056b802ab941fee3843b9fb1cb4c767c4a268>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/34aa02fdcef884fbdc5f3f85ffcbb72ab51e4d7c9b845342f14c1c77ec5313b9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3323a9d28b37fbc1a513e9fa79b309b07a37c1f815ed0b8e45a9cca9bd3c9af2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/31db97c9dab7ed09b591d2f3c567d47f70a5fa66c9ce3b4b2aea1e71f1dc8e76>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/31bceaaaa3f4019e85edfe0e509340aa30554d0f3bb343616841c20641788b6e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/30d6548dcfb7c34348735653488fcac6823660b33dcf39c3885e598b9b5005ee>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/306340a51c1504e59f1c3b85c1ba1b62de8c70cb94d3998f27819761bcee5a98>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/302ca100d1f4970a9146a513f0d229cc6e67bda5c968eb176d1c4f89b95a20ad>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/2dba80cb3ee4e036d4658d3b213c2f0ea89b9d9dcdbc9878e84cf2a4a9169b24>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2d2d917630ed68cd8c3b4a97e39c7f177682d5f8f700b0852621276b221b2a7a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2d25fb962e30ff1d94201523c329736854796a86d345cdbb9412205207bd6b8e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2d25be1712e809bbeed7d439c93bace752e0742f6b2ed9802302dec9a8906e2a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9e6b6eb3-2f0b-4723-876b-178dfaecfddf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/19483103-318e-435a-aa37-45e485406ee9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1ca65d65-54ff-4b44-b750-bd70c91191af>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:add1e4eb-9ec7-4ea6-af82-335aa76b7d48
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b8bb293d-aa22-4b43-bda4-0b6af76e9493
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fd41f573-7d9a-4d9f-b7d0-d5b6114d1622
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/96748b96756c2dd9b57dc046596f9b1d18fc127d04cf92966021724e98ebe80d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/96b45b07fbef0e8ec38186813a2f9a7c509ca938c051a3c302861eb0aa6803e2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/04a7284b099f5d7ab986209789ba663224c6fa6270e8c82c4d9a58979869d0a1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d64b138952736de32fc75d548c9c82b3e9be9cb8295750b8e63e07fac2c4971c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/48fa9ea1578a67db52d3fd572e82ece0577a80239c4438d32dadb612c5b7d09f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8495bf4492c65a83f4edcdbf82ca32b4118b337291cc5b9b3cdae874cc06fb60>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/96bad0ebf5866e1f4d792a276343d492ebf21ef4cb84634dfb27daf0fdd28ece>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5809888c4bc3fe6708e4bb775f50311edcfe2c5e424b71f8accb62e8f7a32cb5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/33a1886b07b64ebe3a0e6c5ed8086f030ef1109492cb254832a716dd7e1b8d7b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/76c45d60f05bf8afc8c71859342b69cac6a57ee2b320b900a60afd6ba9b8eb9d>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/53a387ec5738c4e6ff76d40c88a27e291e895c0fc85a71e772e921313ada2d7f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6eb1ec0b01bd5d9b9368d7bf5dd1ebad6a73679a24a673e04fb88a66362e2f03>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dad16fb4b9075c91432065d157e9e3ddfd6c65a7a6532d75671692d2def9dd02
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2c6a3b01c690aa0c860b5a2d8253b7210932bd79fc308e5b8debb67f79d84f08>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bd05ba17a726c2790cfa5b89c903586d81cd29ce2ca25df1806f628721d4e64d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/23878301a9c6163c4a836d06950bfc9c681a1ef0e40a51162329c32dfc061887>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d769b4b9411ad25f67c1d60b0a403178e24a800e1671fb3258280495011d8e18
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/747d235d067e1f04eb12261b79850098ba93cdd3522cb75bd84e4605038bc76a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/64a615714901b84561abd58d820d61c2e22e89ef6878170e225d45639caf7d38>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/02874f3269bf1a5d7247dc7b524c6ab73735bd83813312c3f8399d8182517450>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1f13a3d2716c49cede296f15407d50def7afeb10c2d7d9cff9d4bc774eb01793>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ce39eff693181082fb2e432cac54662e0d653499465c4b2a695db1ed5be8bdcd
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0ab15874de047d318f3dc3575f9ac88e38eeed09b7a7538df42ac3c7c3c607f3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7f2c5143806d6110feb44eba2a91d58e8fd563465b94d0f6b40d13a6a1740940>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/271462ec6082dde63034d79d808934c298a28d8e9593cecddb802d8857d3ec44>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a0e10593de20daec75c7c987f07db727dcd9dce7e2d2a8797b6a0f0f7157b14c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:af8b2789c75950ed882332410124b5247259ad7142e77ea1fdecd05dbc53a848
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d46371c007fc5caf83968d47133589353cffbd96966111bb7fce21b23faf20fe
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/86db2b72b83ed1ab8b68d4da00639c883d786f425ee1d3f2ea8e76278bfca4f9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/94c56bcbb9692f00b27a7411599cc08f39128ddad93dd822344f428ef67550e5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c3254bf9b0bde0f1a34e51d08f04324ce18cc2e4a80a8b3a3efc7eddc610b01b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ba8a253d98ea7d2ab1afc43e5e2cd145a12ccd86b68e71d023e3c13a83d7498f
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:eb33e645ecfec12a9f701cc21db2d919242d9c94812a7b5550e158fd28d8cd9c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cb6ea2dd7a009bca2aa4c1058cce5545420792b9db0a6b5516e49a4ae4b03701
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/44f5a21d4631e391019d4d93bc700b64ad7c44f5d3be25522a003c5043ee3097>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e1cbc0a059ae4b2ec31dd923159863ba1af30ddefad9a65c812cc097c34f9ec8
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4f4a3d2d9a87bad57bdb770b0c52b1fe6fe4064fb48f1279496f35cd3fe3c1f5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/904ebf5719a5a4e125a3f9fdcd25b08e336f822ca786dc2b30dfca927033e4e4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/50e47a0ba77a92d74e528c1864bcf5b44b01cc20120fa5ae2ba16ae24d7642c2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bbc23313f4c8585a0c51f15f920d77123356535cd1cad9af38f5707892c7088d
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/848084c89eca07d30d0bd8e5c8611c079e1989dd30535c19f3d1e7b07da05be1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b9171544b66a3db39fb8fcfee05632cf4e40e99c5ee2adfa6bb01c4b1710d964
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/93746445b8e49813e27e0d07459a2dac0d8d4aafb85d87662addecb3644c6c02>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6bb0d24b600f2934e4908b2cb0b1fee97f618df652c74bef4f5e57aa04bcb2c6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/56db39c0bb1c85e9c5aec9adb3f5af9720d4702e30f4772aecd272f03c7becea>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:fb1be873c4b31e391613dfae8e68edd694b1fdf126eeecb502b1e5cad6f2f682
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:fad1ca7a-ac26-43fc-b167-b8ae4f873553
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:afb26133e0a188cfa468db610b18531b22a631abf4c24187d4a7ea2f127fc581
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cbce9f764b42a5c0aacd9c868ed5899901f9717ceda4fbbddf3af6be70371022
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bcbf100f2c73def5ab297e49a91d1086c03412c979d5b13154645b0794b29932
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/405b8adb3402d8b3ad4d22e98cb96afa3fc3da08b9eae79b82e9f3f3f1420677>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f0ed2f07f8bcb8ca171f327fd85bd1d6698d05da6e858a0edf0788b67509064f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ee5d6d9da5fcf9e7bbd5c60931e37451f6bc816233c9c269565d79c2b2a37af5
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cffc0ca7d178a6f52a83668200ca2e19c54e0ee78e0afb1236db877236e2d8b4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cd4b2db3d4bd2f4776d3dd65d3e94b01277676dca5389221a7efcead1d336c12
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dfb206885f2dfd9257e65364956f70562e52d55fd99702dff117c8f24ebbda43
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f6ef0202c1dca780c66e269f2d21aa39a690f4c57ad05ece63f178b629bbb98e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b20aa3d0e5aa6c75af0710d94db0a30952c0c45f62282d9d8df8a4e15a9295dd
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cbf76918872399f21eb1c979e63d4b10df940eada09955821fbf52bae4344677
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/50273e406d564825a81c47226da0055d55b4fd1cf92d8ac56d83e4d52822bad8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0229d2fe575a7beef10ef69ed2d7fa364a3012e95986cc10056e77b6b5f811e5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ac2061ba8bf8c0658d7251c0fd2ee255e71f4b41d97ba156fbb004c55509ff4d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a25044d6-d9f9-496e-9061-b0c858dda944
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/43ad404aee5fd4f07d575e118883934b0ad0ead0ef8cee0793b7f72e4c1ce19f>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/3b38fbd322454a0e9d1e9fdb290d6d9629b1db6ae476afcaed2035f339cbc5a6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/917225cf1e7f6ab53fd4ca406520697df38381e3a58b3d18a126b651bc9855c6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/201f85f3d130bc1145ef575de1ae82d390eefe42ca0b0ebff886ee7822085cda>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c78f64baa2f264a2c8b5207f788c285ffc1c0393cf20e6fc83ab61548a2baf9c
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/39c1dea3c4d9a91dd4506e091fc845d3a7f97c426c7aea3e2e728524c0809354>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d6a04c16b842c671407bccdad2d3b536b7d356096ae24e7c6c6e22cee4296db4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8741ed200d8fa26adfa6f6738f1544b161c846d6a90863c028164dfebf540cbe>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/74d03e0964eb006c22ef3ad3230723b3d5d2ab2edc976d97ab8b23d4edf0bcef>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2b1c96da5ba86a6dbb84af9f53b73d8e3f9e4b670c3ab155c9fcadb735d7c31d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bf771996f6be18d3198e1ff6b08042406fae5d171bc2c1dedfd756b3862131b6
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:acdeb7c6328dd534dc7a13c9e5cb0f46654ba89d062f2d4d957d8e5e898fdde4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3799d1366ce54062742b3fd4c46514cec369620e1a760ee9b019a820ed38078f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c5623baf3970c5efa9746dff01afd43092c1321a47316dbe81ed79604b56e8ea
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e195db74c07230ca36d6b804dca8e054ad7e7e5f0abe5ca61118a39bb4c87d83
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9ef9220a7368a7bb42d66f537d5bb386c44ae8d6b7c9348d49a0002ca019fec8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4018f56b73fad17de5fcbe818dcd84e78daa28e7c04669c110107ef844a6e826>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6e7a231f4734064a38a6e347d978a5ec06bcbf1f749820791ac6bfa301be9aa1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1eb6c18e940badefe06fb5412742de87844b6dc59e0df795d43921a0381ee377>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/55320f120f1c2586e93570f0eb123242760a424c355014a41afc1f4465c5f352>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7964584de2575c7e0aefee4a2b87b28efe1cd0a3077fa750ca75e37e9afec485>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c746946756edbcd64617216e752dff9ee8fffb1f6315f621cd14df0704915550
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/76241c2a97ec7b12f9dd4357d916a627534984977b77d9c07bee0946c97ae6af>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fef6a0b451b73385de3e432650ce61f7ca4c53c64cb793a0ae25b81837e9dc55
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:aa73a88fd45a6997484779b2e8e5a501a60072cb370254e8365920540fc316eb
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b001899f805ea8857ba54229bf128eb1de52ce5ed92b15ef4f396c73e89b3ec3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8491a95c3ca6442b38a1359131dd348299ec1ec9d5316f18d1040e71cc75914f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5bf06ce5dbd1eea7dbaf00cf52fc517b7439ab7a9c5e607a269cc26cc8e27d70>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b4a4fbb03d7380abc629cab4165419b537e34370329551913f457b655dc07b15
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/523e4dca403e88d50b349f71e20b46c89cec5e04a35c1c09f76f2bcff4b61adb>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/99551d67fc22a429595d9fac5dba1babd38cbd823c7ea107b73382c30787b6c9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/79e613965c6300bb08395a2ed56c1532bda0cef4da031ad5ba630313454937a2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f10e9ae6368cf490e3b390772664ab6e995ac6605f6806b29c8eb52d937758ac
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/32da17c087bc35bd5ff2c44fc43a225770b98e08c104a4d741312fba736331db>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dd7dbe736a9dc2a116cd12fefca2063e903574d708d153427553d4afe01e640e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1820266bfcf4c0c9cf62582e1d2e4f7295224cbe24726fde42fd9bd31c76e632>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1b302e59584e383bbf169280c7f21070c65332a58ed4e80c89fbd876edc4cdbb>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c1f7f31c96d4e985ae41256349250aa18e7e2b2f7bcde6201b065e6a0e028e26
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/83c7a12a4a8ac8dd82895715095a866dc4794e60de61b967419bdfc1e207ad96>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c0bc99ef7235a43123f0b0f751d2851b9218c8790f6eba4b921960cf464f55ca
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3796fb30264292b169955088a008c65b386e847e5f3bf0618eec6e22f16eb8e1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9ba66c8f97bbc6dd3ba2b35d8a6bb79215facbe3e5b3d52672b785449d6f5e58>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f9ee0b69624bba3677b18b95110246ee9106377c948ab5d914909eac79f88bcf
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/929477e6b82c5e17f1cd7b1e5dd91fcdfddf7a1d981d842a95026373d06f1b3a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2cc9610e28efbf6dad47a109e03484ae59c668a7482f843cac4f0842a929b44d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6011a5d8acde95d23f021cb53d31fa95d75391ce404466c65757c641d6207f63>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d52bb1ae601fa75cfdd9d1a2208545a96b219ea29a49bb8d8bcbd10614607923
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e6b3f07f54fe7a613d5c6993de6d4d25afe28d1dd6e5a42b9ecd7b5b916c5819
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/13b25c80-8d3a-4821-95b0-ffc4e850cb4b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8e56a0a0b0d98e418bc12db9df9750ebeb8735ce96bf7264b69c0ece34cacbbf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/578b3a0e938f41f0f4e1d4802256198d1ef28e86b1f58bd690a537b6d2fbfd17>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cbe8c66f4282f791c6543bef7a102f8abd9199452aa87ffd141d1c6524d01700
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/45304946a1d7ca07e95fb5de4cb50df96a75cb1583c7df5029930136bd7ebe38>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f879d68d0f66af67aa045b1194cde7dc5d82e3bfe07746cc682be472c9556631
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:f78a1659bae67fb9b1152dacde0e5be24b0b49ac14f87b45617e689f77be46df
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/257500ff9a8b2ae62dcd338528143ba271d41d1f35cf74d9c0e575e1f3a6cad9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8cd07007fee51d55760f7d3d14944b548d98061a9eca4eafe825c89a1145aaf3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/55aefb46ea8c9cf9c630fc4c129d4ac9a0db689af23c12896b86a6c8a707ad7b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4b0367328c54e6af11eb0993c441fccf82cee4784623962b78e5ceae7018f6f9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bbdf96b9ca27ee19cf518be59285fc892677a0c77b9bb22172f09d93e729fa14
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:be5f63236aacb5478334077a901dbda6816a7b923753b49c06295777b47e6aa4
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/2b814c506530ef42d4f7e9ab83bee10ede35c9aaf5ff9ca95c205040e639e703>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e3e940903cbd7fb41b9dae05802d6823330897b4889abb4bcb53d7e6dcd92ef6
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/76ac18db79a6c10285e73d9c2d713908dc4ea9c8db0e537cd66b7dffd3f08c4f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:aabfc4d66b59d5910872e7093ba0ae19df2cef3b85f849f42313f0afda1af6ae
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/68e8c071ddfe1957b9c7b0ccd269f6776f4863a5f5bf4fed636f0e76427200ac>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6df8e0bea64384f82abd128b92e92aeeffa4847814c0205ffaf9e772e75bde12>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0522694a8581edeaeb3526ea5ba7f2499654105d97ada0008a79be32e0e43dcd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d7dd13304150f5fe65bd239093ef08dfae107864d26299ac91240a88782aed54
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7c6b38fa6fc65879cb674a654617de171adfcfacba086fb918da3749dbaa43b5>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:f2a9a2392d5e4c0f992a84a0871d048a7b91b14681e9980a63aa6ba4b1f7eb8c
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:de799622f0e0a928b0409c401d18d2ed7dd5a5dc165a8bb8e7934f94eea77c44
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4b3ee479b05e81df72e2c2d7aa42c5c77fd20938feefa0126abfff98356bbc96>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/384fa8a2b8bca7729339e99914597d79c07f3385fc367cdf7cc3a28e31892c4c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6c0cee908003c04080f2f07d86c669c42f3ea69eeb6a018a78261d61b88e102a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b6f47f902b7fc800109b56d643856605abc734c2713bf6238d10c4ab6717e407
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8a162fa437a54cb657b57514e4e0135ec106fce3206c29cd2f90b1859ed90dab>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/90c172d539a2ecc6e4e1681f1e5cdfcfa82784f9e5d201e7e0cce9b9b235d08c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d89fab85807c017c1fc3391375cb8093884c76baaff2a651a9076412e9a80cd2
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bf9a29f384bec402f9aaf33b49942fb743e9b8580e3e17d77711d823cd8317a1
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3f57a17fbcdfc13def910c54948bec11d71d3f75946b0336fffc0587bf18d783>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:de1b368a9134ad6782b22e7af616d61019ea5c64d6493786d904d53888b42d67
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/201519f35e14c5f67d0ae819831be4ad60bbb87fea40dab4ca5ea4eae018b4a7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d26e802b-cae8-4c52-bad6-39e349d46862
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/467787c74d6679754685d3bf82e7f628634f7bfd91dc428a7bba32366c851c2f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/787ab1f73a70f179f6bf7f67a0cd74c6b790666c9b0914e7c2aea23a1a832823>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/120d2462-0e97-4636-b8dd-78edc4b2ba14>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/45f432ac38d124141638c62f7afd577ab847c3571061b45e3b0b3329f6194048>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e043234fde49babe55530e3858c48ed948fde0fe783fdf93890067581fea165f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ab684633d605d93dbbe6b9ea40667e2bcf03a0856cafe1825e95b7829ed502a3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/81c963a775083e79abd30962c6ae585c9d2797565982d4a486601183c01a8872>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/19673274e30b682be3dd3178352611aa26c28ea8907fd4990ff69e01af7019f6>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:efc00af720c638ed6425d46051f51d25fa7a624b973b2a07c39ba4498caee78d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/43e3009526dac139a0abdcf75c1ddc5fa3fe9217391d6f64f7b7a30a99a4cda6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/73dfd8ed3023297f71f6c4ef833e515e7caa3e4a10c9caa032576cdf26c478fd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/44e59e452ba64d4e0d10167d6978af59dd3680a5a4ce7736ccc5973bbb476e66>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b5a995382b4d908862d8203045a669c3d058553c16a4e2370030a012cf5f74bf
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d5afbc1a5906c3c386376e82d9930d29c60812ccf897833fb4dde99e73520914
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7831d6c59a6175731d8158454acd881850f1915a8628426f3d91d3510ea37950>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/859f08dcfbc8f68bac0879e7baf6463b260b6f4c16b734d0d1986f5f3af0407b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b79f87dd99048218d7ae8c9822b56ba2ca446cad6d020435eee7e960ec7e76ae
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/240d6c23ed1488956468b3c2480f3acd1b69fd17a536f6731687d3066e657f45>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/76730bd9ab6808230335d90e9ff30ad362a3461ee0239fd978e4313bcdca44c5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1d6bd844667629bd4b3a630789770e57947c7496845fc706c31bc2d9314b71ee>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/56061c5a09c4e4fab34edffa2585bd47b5c104edea687e409a9a926b2197850d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2712dbaca999e57d26f1f0d3e72b2ed96113d6ac62d72b7228fd682e1324e4e5>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/309381680ffa9eb3465e5dea5dd873132ab4333cfc5bed09f3c957cdd8aff0cb>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/708128d3128fb87ca50371ea08b3778d5faced46dcc4c42e034f101e1b7b474a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/034acaef43bcf9245ed7256b516a7ac127b9d505509bad7387b95794b8c15a0e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5bcbe1dcc6bd42354ce05e87c56a09a0e62c2fb67a4e6def59a30d40b1d70e4b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/60a7cee610b31a63473ef8f52665f60108cb2bb7ce0d1cba8bac7db5f00ab318>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d7647bc0a8e666de25cd429da54fc9e9909f886a177cb53df304f1273636f44d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/12024280b02353961269940c14f4a2085b0befefa81d5f12fa967126d1f6accf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0816e453ed9171894e7b79f74d83144b6df186c94b9266c4c240280161f443b9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f7ff1fdfec6a85c01e57c37039a91563d75b246bd69f30d4099999d93a0abc02
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6a98028e3e68cc51efb054d7097684a14cdb091eccabee5fdb022b6d84451d06>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2d7c728af88ae7785057c04d6118f05f5b45a65e06b2f9b12a059925f0463e5a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:de085ffd17e2b1b37a6069ddf36a4d6b2108e89a095c3143c620759351ac9cd1
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b694643b656fb0e2e4b25979e23f2cbc47d9780cd27e2914983aff4f338eaa43
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/986bc8bd29af2847bdaa104fe5ff052201032f3e5b95d7b2ae3a3c5486842a94>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/49eb35983edc02a14dbcdb37833fd798e5422aa8b03b3875e8cc7a18d1b2b853>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0b5d1664b3cf08550bcfdac0f4b195ab7a46a0f1974726de864dc0edb1565ecc>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/881c65df7571ff558932068e7b6ac5becc9ec03cf078f802f6b5088911a7538e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/371fa701c757106e5762f522e15517b043f0b01a5f7812de5b2142637c10d516>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/037bf2c12d939fa29aa5c77dc274b32ed7ac29ba9be068e36b0da950226d5c61>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/04895013fe6301f32aa46deae98abfb833a717ece5a33b6c453674c6d0f4cc5e>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/3034a27a33930cc51bd440d5c270e96d7e536caec358175a57d41a0b9879695b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b1921c8d18412f385e9e04779ce742b844ebb6f2c9e62f2f7f0737f0a0be9a05
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/55703854f4eb9eaa206e9dd32e4c8a4475f258c499ac2f712f0778b77c342e1e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0a6f2c605c7513077bd8f06162a9b4dc4c7aedb113f15a3e9e8792719e9b107a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b8bf3d26396dc67722019c522d3a0bff2c6f5930694f3c685f6384e2e6e0b2b4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2f570478b85dc12e5a980f82160a7b697fcff807eaa0500aa6474dbcc3383ec6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/45cb23b65f3c877676288af3818da3cfeb6c6fd03fd81b4b0036ae7e02d3f5b5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/461fdead3ed31710eb58da8b8acc22a08f82409c4edc3adf220ef2f98aa57c30>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c6ae77be4aa72cb5f9ebe979e788106a353d48a3569fac740a78fa47fd1a1c72
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/518c31a6e89f514c075e0927bce9fb2c91a552b6d65208c04a687d4bcb81148c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5d21ccef2f5aa3ccbf3a74c6f25ebe9f0b1ef5a97b87f3d79c86ae9d6d857df8>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:d158db91a7497ab1ae9d2b07d7dddef323169ae483f6314dfd5ee3e9e1393de2
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d9ee3dc7b107144c145264b6aa43b263ef51db6ffb523b222e1bc01aaea4d6ad
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/33abba8b7d29dee8ea194d2751106727c01576d862e63b4eed34cad307ae7098>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bddcbf81e8263f5d147e750f760e9e62242331ed8036eac8e521cea2d738918a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/691c83d1d956184cd4c1a97cf27485827b51baf87321e16ea599ffdda4e4b78e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:aca53cf11877dbe2f303722b110a86c835148ff4a167c30654ea9dd008c9f2a1
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/880c978bdf2b0e3dbbd4644787b0e78f9325a865e120e66b8aba2f8dc2967c1f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/72bc672ceb6894d8dd31dc2dff2faad2fd93f4b9f5347d556d092516eaa30aa3>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/51793f0f16c2b06e9c64cbc141407fcafaa340576c96988971dc0855f032940c>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:ceb1cdcf01ffc68542de2b1e0f8e6f1d581b0267d85fc7080cc451977dc42c5a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d4d6c6958c0600db0d1cf82ca7642c1f3789b9342230b6174d36c50c0117d5bf
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2e6b922d4f84f378b341c2b0d1bc61f4c64e2ef726dfb7f9e863752dc8f7cdc3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/59bea65e87e95619e4c14ba593ef00009a99af8f44628c535fa7dc6c751e8e38>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/15cd743b38bfe22875031bac8c66d32f8f112db3511e660ac28c94271e772d64>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bad14fadb66ed3809c655c9d07d8280a9fd5004c47e3131e0e67bd81f0b8182d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/628de4b148e9c3a540d42ee4d6fa98810d8016ed13bd396c9f80bf432a3e203d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2a2b72be37abebae1315732f80247dce692f8bed094361611634561eed81f73b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/304e5a2de1d040e482304f4bbddda1c0237a9c6d90169af3ea69e431709f79a4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/30140eaed99f7bd21ae29da27e25c732a0e7ccd5a54b5fbc4afac00dafba6f3b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/10a0af7dd1ba91a385a6ccfb2dcc48c8b306ba6c51f2935b1cac0ac6fe2016e2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/82d4abaad7dd3d7a48545f48391e64eb7ec6975072927b36edf8e8eb34980502>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ec07b3c9e3fa08383f7be47a633ba4330c29771769b8e4aa9608c9c1fe130d71
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fb56bc40ce36390d2f12fc2057c89d4b6bc5b3217eabd41995b6401318ff648a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dccd34bd1535fec7707ce7b19c76bf5446241926e4b951e37defb87c80e24218
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/785e8d5516378c7382ad0e7e356d2301496d810c6cd46d72ccebb455d3ac525e>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/3e077115eeb70b649d44e2ebbb218f2cfcac5d84e130c88584f0ec23f7cebbf9>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:ad6d197c35a0c3cdaf03ec0668e818327013ab3c50645eabe5840ddfe5518f89
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0063f3bf54b42af14f148c0e5bb503ee555d7dbc6926a0eda03d5c523809ae4b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/92f38467d9467707d91ba9cb3c5c165cd58447078d985b25a651b3f01e8695cd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d4f223303e1f925ebcab3bf7d42be9ab847aa5ec413d64139c5ebb76a15d7d73
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cc1d56b39041957b17f7a24e80076b633e0ae7c582e616806b7112aff8e62efb
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a733c5d62773299fec8ed05a9ff72eace407af42171594638d2a3f832d06f110
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/875f34f4563fad2ee7f2fba955ca78ea017f1d716c08c49235bd1cdbb625b77b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6773d718ab6fff1e3738106296c9c8972f8dbe311fa4a5c78547512eb9d2789e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c6c1e26226de1a32953583825057f977ed1e4a942e77fdab927e49d744399907
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c5605cec98e351189ed24796350db8866e918540f4abfb6a038e339c72afb875
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7bb64e4a218c92f177e8abaac3a7d4ef706fb6cfa28246c397bc9a75c1773b3e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5f7bd773873d0f3910802f9855bdc2b6738aacc44fdb6d8ed45cdd8220f10586>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ba64836606bc59e1334a787a10e97766268fd98e0dc834175963acb182ad16eb
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8726a8c00a0febfa0944a3674145905d03f49dc3583d14d27b3ec60ea7a05f99>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a4fd24f3-cc6d-4ea5-91c7-efa02d3b970f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f5aef7c691e862d39758f589e2202f64ee91d924938d8ba42de5d1a4dc26b38e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7563654fe91b0e45cd57a0b2a6e786bfa5f34bb032f360faad7a280bd6510c1a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3241773b6e80720538692a56fd4433c622115aefc8610d185365df478a09dc31>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/144c75e403c5084af57f5c0c86252b8759b56baf9694326abbcb5ea40ab69f1a>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:be274f73ffbd75a9cf28222f45044f468b40692ca9c80c8c5899acf554498e24
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/97b3c6867724768232d06832dd1960797fc6f3ae9b3fdca24079e155dc50e62f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3b7dcd5c1f24b05bd345e7b2fabbd9fa4d3301daf5fa196350cef2ed2c158795>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/79126ca51f0108c40c0ffe95de2d08979e79de89b1ad87a5134a49049fafeb1a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e3289466b88127a445e1467a360f24221bdac2723613b8adabeb131e8d9a3659
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:eb021d02b04f6a35d27f1fdd206dacda742ae5b5ec8cbbea1d5e664545e98a1e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/54f52dd240e24ac891f9ec97506fe248ba17cb46a84aac4da6f1916bb3111022>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5949ac1a19026206ebdc67b4e1a63416bc0f4fa25615295f185fc3fd5b5181e1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/11228df4ed78cc6b5c688c561570fa3b2a609540db8482a2866a8ed0cc398b08>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/785715d2822814f7dc0b3896601b5b777feb1ef9722e1c54f4cdcc697594acca>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/92207a4e09455f59f19553e95ebc4ea1b33e6f7b2e5cf317ea31ba7ac0cbca45>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/32d0fce422c04b004e3cf640d3aa06468f8ec8f650d578806642c1097b95d782>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/204f9fe956eaf101f6e268a5403ad8494d7ed532d5fb7ea7334543b1e5cb916e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:da5c2f8824ae97eb1408e04217048f252c405ce2ab943f4147f030dcf6d2838d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/96dbda2f169c22981edcd92a69f74e5eacbe62b422b8782a7837e724da7aa755>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/12c39e825df9ac4d6ff12092055d73b8f40834aee307f5ef0b7551f301d0dfcc>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b4aa549332cbc6e6b92d2e466b49af8111ad67b774ee4c990f98d3b77c5c6fa1
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/772ed719a9478a76710f3d92bcd43556cb85a1ebc1c04e9561dc1327df846c4b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4d7946dc0b77ae0cbc08637f4e1a0009a58305ab5da33aadd75c7d4748340b86>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3834647b5e95ea20f5ffe5a12a09fbd3d7fdf0d187fab385cb7b841422176ad6>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:f6dfb1fb092ad4291b7921df8214dd9032c1c0fd198ea43264f5d2ac033f24a5
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f73c7109-06a0-45d7-b558-879d87ca3553
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9727dd2f315c2aa8a87ec657fa3dc24c18a6ee6c813a57db008c9ff479dbf144>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d3c76fd84794dad5e12c9eed6d6332dc5e5c99daf0e4ddd7ceebf13d5d6c0ccd
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/5d6cc695e6c2082ca219baf425c61e8fc8ea25ec5a11187f1d96863266adcd64>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d27f323f877abd097699b2c5a748bfe41bc83193f8c67ffc8343a335146e00de
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:da963630eb61b9107c5db60ccc3b0bbc5b8954d0fc872b6e39c224c447bd450f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c895809729a165666fc111a40affe229f3c8e8f1ce9dec2dcc1be1ed81b52d9b
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/323a24f2fe81ee0b6586ec78be36760e478092e07386b2785992ea8b61941833>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/42a43591e0db1dca9432f480f0f49f9bd4056c2b131e2fc997497130f5e099d0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3dc438677191b88ea491944a489e8137c09aae900924c96dec52352e086f8c3d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1b9e9954c567331e845b8ca8f423d4c5fcc26aa377a73db1e30e0be83eac08cc>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/09236fa913f37184d201c3cbde96f83cdedde977846fff7f366bb36207acf92c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:baf514fab1fdd073782ab06efdce83b651bb30964a29fc742c3435bcdeeb327e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4ba9fa65d8a6cc44a127edb470eda4f4a40aa0f1f1d28825f785fd4809a2af96>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a2ee394059cce91526392e73e4de974d90caffb92f70cde23b9e9e1a965526fa
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b5b5dd1ba3ec660298af91fc1a52367f52d4cf369167c4c93c450dcd9a6f2c3b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7e7bcc5a4794e967fc42316fa2dedaba81604a755223031ea3c99afd9308b98f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/60daf27c2cf12dd123447aa300dd7320890391dbd8dd6b4dd7ec02258f8281b3>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/9c511eb332f61498586e50047b1f238d61e474f3e0942dfdb3a8aaace804cd3e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/026509cf3b4eeb7ad88fe57a270060574f60abd1c3524837d36700e40809d210>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/68f178f0390b63b5f0c48c9d0e3e91f0b8747155189f121c129dd749dcf52906>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a16924910bf18adbc3f4c1f8a80e8ed653c1bb8a6df289d23907b5400ed05bb4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e437949aa5906b1a565b823c0f707a132e33b9acf55f5ddd58e10f2e5ee9d1fb
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7acf9640b540b3cad9268ea04734134e0687788914c89a353c54d04d86dc8a80>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/356961b99a3221ab85aaa9ed6feb26d4bfcff3c22207efc9ad87abb31d5dfdbf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/004eac6350757ce2688115f284907f42f1ce6ca39ec6b8819e105eaaef005647>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7b4c40e89ebccb7e3e8b969d6d093488e96ba99753bea150d7301dbaea1167a0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2fd8218dd4a404931eeaef879e33506ae998e38d4ca745620f4f6044c230dff3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c275e4917dc07249a9f833945018c3d03408dd455736ba9faf2e1b4410b16c3f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0cc6cd604ef836cd7c25ccc83de3a28422cf9b9e515ced6d31defe7c7a20d88f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8a7354b76f3d258f9596fa454ec2b75b55be47234366c8f8d7d60eea96dfbebf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/73e8904d83f7324e39abc0adf639b0e48bc52533c4c243b6419cac8fb70784cf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0a2d980559eb9f3e0820386541274a72692f495204cd6d951ea1907ecc65829b>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/051bdc82e217d8570decfdd7cebaec496079a7f7ae422c4570b268269385af56>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0f90ca7e2a59ef6eb584179f7d6503661f7ce3c1c1096fbf3d3a8d0b4b07d51f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7f4a152c7aaa7e96f14d97b2bfc150d089f06934d8aa88ce033292b9953d8381>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:eed06b7f96d91d0d61863d8085d3370416ebff5fdb80c8922e4f0e0bbd4e8fde
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f56f068943a99059f5bfc3b905fe8848a25a47cfa30fb3ed3d294b47815b2255
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/624868cea426a756fd3c73ec1880030a0054b1736422f4897bccf3f596ebf538>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bff95ee9bf46fc421ec7d1549df0a2ea5766302510c3298916d33a7d713c1b50
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f5077ea4d13ee6d74749b2d9e7de428b0633388a10b436984859021cf62731b9
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:ef6cb65856267721638c26272a9eb1584a9516527fd2ecabc1627d26c3dd8dd0
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7c64f3e2c9830891e559f203dd2cc0c065617bbd2b91d1e380d10a8521cdb7a0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d3abb7a0aa838ba5641cdce07c61803659ee32e66ecf4710d719eb98ddf0c8dc
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5be3ff820769b385a32e499d17bbf1f15feeacb65381d5384841732dd4a1209b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/122817656206dc0483f5e9304d25fe94f0ab113293ae7b21ebf6e0ef4ec89604>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6861e7ab92ff73b8d448edb2e16e9e400201c5ceeb66afb82b185adef4bcbaa0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7125fcbfb7a08f8c01efbed115cea602db249c04afe9b5a2cc298cc7949cd040>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/5dac914e84e5b9293b3457a57007ede319ba8e7da44cd7366593b7212c21bef0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/619f6c633643d4bbd15f6d2b63481836123a1167dc1461dffc80d39781f2099d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/65cedd4d994aa2e818252bbb4672b7184fccce7edf673d3e5571da51dedf6a3a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/80b9cde1dfd1f040daa29e19818b79630175565f3a087ca6c0bf44a61fa3c706>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/65e28345eaf58a1900fbff273bdf390937ad5e5d8682668c256a2ebfec39ac37>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e7a75861661ee14ebe2bca0c79bda8b23f2f943d00a9693d2bff401a8f8dea65
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9ae900a5447b7d727ca6496910220d4389aba7f1869923f1bbf9729bdeca28e2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bf4a505b56482d3d28f3c4b29a6c8c5605c508f4a714006e2c00c9fe3824a488
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f1ad80291fbdc1f0b9b25d729ecc608a8e28fdddab01a1b8e135c841c75586e2
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7d80e3a1006e3c56299a1e1f028a2dbfb1163873acc914b6f024ea56b53a4760>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:abd55b65c3192a96451b1ed25e1f2b694ea193ed28e0380ad4d7bdcf183226e5
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cbb5b8b80d03be75744a41580e5658b3c236fa0a12822bbb334f893c524b5b18
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:c83586e7-9818-4be5-ab24-5e9dcd9b21fd
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d615037b0881e54c3a966e5a99a75c16bb1ebc9759e0c8f220b373733aca9d3c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9e32f9e09afd6c2fb97333251def939d5f8e0b59cf2099cebdc5837dd915f3d8>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8d71b78b3048c4062561b199811a6de7d49c8553c794b6cc62a565e683681ed4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/49ee71abbb5b06208ff613b6f06768f199b883ebaed2497fcc94aa4c33d4aa01>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e4d0c70f329fbabe7f39661995661105f04a19260a5d21e6b30a702e1976ef3c
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/1f88a033bc2f961a1a1f8081160c613be4a82bcefc94f65b41e8fcdbd87a2d66>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:d292fb446d91b6605dad7696df0a0a7905663cbca7b0c0e167cf72d4ae6900da
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:eee3be76b21c7862631b030da2bf267915cc128801eb35af1ece608dd7d3f169
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d82dcca3-cae5-4cae-bbfd-fa4af2bf7aac
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7fe70d73b97eff8cbb7bc4a28289d3c4879fe8c1d0e61f7330322a1d4419af97>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ab9269754d1266e010c1878a1199525898f0846ff0e9a0add9e7fbaed42ac43c
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/7b1c9132de06d5b3626e7118dc16c7f129d7c911b3298a0f4609725372e64588>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1165717c-1203-41cd-b434-b041cbe66782>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1cce3025-1033-4e62-b276-22d5ff341336>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b9fd6a7fa1ddabcaa0eb9d2eac74b41d5671623a6799a520308daabb53d5937d
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/342b455c4a859c4f750dcf3ebdc5842c2687840117ab6cac3c991b71306f91ad>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/27e7a364-fe11-4303-9a43-fc2e1a3510d7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f398f3ebafe08244f84eac783b61eac71c60bd39b8ca9ee8d9c2a4dc8638a772
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/807d593ab5dd6a809ae8e9b9b585e97af857cff3850ef62053a6c7df86a223e0>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/4a2864750000a2d8dafa1128bab23143c8725f2c6d6aef400f9bce917bd4a94a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/10ce9d34-953b-4096-9c09-575426b12acc>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fd620aa85d002529d17747ee2a7350d97633144386c273a53a2ac742367b2b09
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/705d1d669f2a47afbe1eee73ab8e9b94421b0aa4ee34c38047686533e1029554>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/51379cef-3df7-49ea-bf08-e52eb8cac4f0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/92609bcab00475b084e747cb49f942abfb9e737ab023a999c69baf60acb8c06d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5bbfb36c2014dd0915548249768ef2fc2b8910307299fc545a03a3e9f9e78c19>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/35454115a5e3a31059e0c4fd55906df42c75885b0233c1f17eb4bcef6e696908>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a375a86829b8d4b7c4ffade0b200ed5047d9eb64b5243b54e072c53a13cfa22e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5e8942a65166232635481ceb22de0b162788200300dfdbff826693d7d183dd0e>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4c6a1597c80c61844bafbb4577a83a05babe77b6ac90811a5784c5e689f9d8ae>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/02d118c277771ca341d9a80b4808f7ca1548b0805b2b93152b31fbe0f649f5a3>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/04e7a09c988feed3cf8df1c51aafe0f0a50811e325f5f5ab8e1b9750f48630fd>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d11eeb1f72ec90f9dac00216e970e250ed50f12d51b392285384bc66866f4af5
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5093277a6afdd795f41e892b96cf6b4103f6815adab1d04746744388a9132d19>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/08293a0d743c13f37e99deddf000e75ba13f70ca6a5ac65cde49ad23d600ab3c>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8686c05a78769749f97db731d7d761d82205d02e30640a74806829cebfd4b96d>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:b1d0b1f4598b001e1f8c9db2d196feba45d182e9d0b71028ce6ea02b93cb4b54
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/836436cd7bc957ec9eb24865c628c5707b4a1fbbae5cccebfaf1df0983f888be>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3691beca-84ba-40ad-be53-d2b009826f70>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0ebab99ea0311baf2e6ac71dabc395f3fd8d457d08b90a6697c4453d1e649572>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3a96e42277fafcfce845e27fc0bbbd083a6cac194a75867249ddb61e10c246bf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1c74544a407317a106a520df62f482c7d3d68f246141b056fd982b94ab2a90e2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5168030e-4c2d-47c6-bac8-b5ca11120c1a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e42b3fb5-6f81-4056-9ca9-4c226173c435
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1da9a37e-425e-44d7-b81d-21c990e75533>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ca68202ecd1d5ce242c56444eadc6662844394e568180dfb011fac1d72078b1b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ceeb43c877917c5edd29756692c60e26225c56effbbb3da0c82cd2876493f221
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f2ceb46e1b3c5671972d80b7ed3a2b98859ca9b805bcb9a39342b9b29e969d7d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5f8d6d52ce73ad94e95cd0f97f8b275b869e4fa79cd8afed50395ad9b9b7f547>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f490a5f5-5f21-4c01-b70e-80d76ad8c256
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:eed6ef4fd7723fca33613bb9c9570825be3f8e50c32ce9456ded3d54bc624370
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d64157ef-bde2-4814-b77a-2d43ce90d18a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6d2c7081-bfb2-4c47-b05e-b75ca3d1ef1f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2abdf5ddd8c7b1ff7ee7749ae8d7250e0150748cb12dbc01de96be4e4a1a6933>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ef67ec9cdeb835268fd4a6f554db25f1bbb081009fa136b597785853076ea937
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3ef24b37b0d48fce4480d1990798752ad85585cc657e48e1daa5f840e0597d76>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e45e6ad275ae04001029796b3771fa418b32414269ee741a5cf120a580ff673b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f2e7afdc-4a60-4731-836e-ce7106855bb9
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/93da82a640436139987d3bbf2cccf7468ce357e6bd93f223e4045583a669052a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1e24f371-3d0d-4aab-adc3-52092ecaa49f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:aefcfaf858797cec5d34bb058c67349059be706ce9082eb75bcd6b85340e144d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5b6b1771d90a683e65f3473ea76c0d37d80d08a8647fd96783eda9af179a8115>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/80a1eada0bfcba14bd568185cc7996aa76c83e3c38e5df97592f8bcb5b1d621e>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/4007911a9bdb6dde20cf16ade0a9520aee8b2c2b2a1edff7ab639eadf9e9432c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/403cf2c87ed174c278f9288e986f73d7ea460aae2472f8ab6c1f2463e643d65b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8a72024e99b1e083aca28a026122ad2bc517372bc18e95210fb54f080136e3f8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/59a00f5bf4b00f2bc64c72d3d3a2d645e0659a662f4daca943995cbf2625138d>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:cd9be459e61b42e1301c7f8918339d8ebcd3fdef7c85d30f90f4f1c160e9ed52
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6b7176c419ba01cb0e13fb6f03bc2b2b4807787781ec6ef4b53042cdca9c510d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3ebc33e54a7b6908651014c5a90594c311d76ca29b00c03bc6a4cbf07a5f5796>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3b7a6d691943806c23f59d22482dea27e451bd440f91f884aeb42e8c72016ee3>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e9612bfd21b5b805074e751d03224dae38f8c4c91a89fd34f1f4007c3978ba91
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/507c26e6-7205-47b3-8e2b-d914f103bed2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ec044510-9e82-4b07-b135-39877ed2dde8
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8fbc860108da43ce978ba0559acfa1f3404a10ea6e6cb6a7c7de9b1a5ca9d1e2>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/21a70e74dbb297ec42d5cc72ab810178b298d12fc8f679c742d2501f7ce5b6a3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7cd078c3db8a9d7f4b96fdf3b1e9123bcf6f077538660e8510ad349862346a3b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c5b561ff9656b79531665343c52b69b5ff26d66ed234d315987b8add97364fd9
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/13ce60d9660b326b449b11c74e34fa85de7a39ac18d8de63ab22c76828ccf3dc>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f4231a68455e39173cc19936e9b1b92497f34c44af021f733df65875389a5bd9
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:b27a3032161dde49a0014809982dc41f12b32d93195611b4fcbe6bc21c36162f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b6b246cbace352468b3d592c6fba8e322f95555835f605149f4bbfd0e25bc6e4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8a301cf9-6611-450c-aa95-b104803180db>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7a26207c8531ac7c1dba8efd78870dd90d2ad64cb0cf3e666529e60e10e73a2d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9b61de8f519e608c8036defc906b866d3e37ccb66b7a90e77e1f44fcb1bef480>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dde30cf4-e5e1-46b6-96f9-f8c16cb9c06e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:efe77fae-7ba7-4a62-873f-1f291b5a911f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cb3a3487159493e27c252ebace45551e6c0a2a07f9f5abb8cbc2fcafd3867aeb
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e3203d42cfc9240b3eb1898cc31f7b04fdb259331354a3d7efa9cb80b589a14f
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8cfb6e37e4259b79bffd9027e38e2a10397edf45084122f3939dd19ff378fe9c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fc6439d961a7fbf710dcfe8241a87a9047dec8c7f734731019d588e55b03dcf7
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f5e0c1fcc79887f8ca7d8020dce6d0a1da714cea6a576fa3ca15a2414657729d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e5f3c3f23f6791de122a5e6f1af83543651d272eba40e138c2fdf91ec05f8a40
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3b796489bd5db442a64f7896c53af2ed97a97f9f6ebfebe3b458fcaea2fb8a4a>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/462c152b4e3f8c6b831e4d6ffb727c112797e3e927ca6ef361296f117d2eede9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c667d36bd4097f421f892d281dc9e7b1948d72b4e75d9999dc0cfab6894cec96
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/75bd7f9e019276e6b5a4d03004c416e673ff032d12064b6d1ff63bc5409665a8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/16a54454-22ff-4fb5-8e89-883a5ec722a3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ad89b832-2188-4bbf-966e-f319930719e3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/907dfaa53225a47fdc66f952ddbe98682acd9cd8285a2f298103b33b94f7576a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/265f6bcddea9c9e994472376c40bd5591df678ab9fdba41d5d65933467d83f59>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/54a772478ddafe4c79af67a9f75583f71e7f561d87b08b16e264194b2b0d3128>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:da9f38da-eb84-4578-a206-72baee1865fe
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1299f869-04be-4ced-a9be-d6e2b8733b05>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/70abdc83-0603-45e7-887f-b8b91beab9e0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b080d8ab61bf66f592ef70297c37ae81d64fa75c7acfa63d71bee42085ce0bce
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dad37923-85b4-4c30-8bd6-050061bde51c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7152ffbc9f34208fdba63318b1d7e87980937c71cc36dfc24d5303567436f4b8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6c4179a4684d97c148da2e78ba99579e4145412c6431e1577713e5f095ff4f08>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e4b4250d-6589-4ee5-a8fb-16b6567f0f3c
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a782c3c4e64bceeef7707ad4175aca615843683fc32c1a50249feee5beb3c43e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c3ad892119de5e053cfa6a166d1578330ad93f237dbda32b67323c46f98e1a9e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1bbd0f7a-664c-46bd-8ca0-891801b81962>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:aabc8d18d6b42c555fc9061c1f756bae12c7ab722a4b4d6408e14785d5762500
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5187962dfd40789953d4fbde3634751ee90b48b17147c585ccf4f2ac1ee72fd3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fdccd8b127587cc2d592770765c9335a5159e87ffb8a57f2f571b1be8e97ce11
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/71751b8ce538b727afac3db25eeb145a87b2415f9a2a02ee3df759ee0abf4699>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/47ac33b7-9321-432c-8ba8-1d284f04addf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1915208b0a66992ee2014df894f7a9c538fe727a975fd9538d9e2c949e1a8471>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a1d72f5d4763982035e10c5e071c114d2db743717af82a92da0b296cf8a02082
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/660f7638-ff21-480c-a4c9-040bce2145ed>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/1aabd6b049a964c3d11df43e787bf9b278500df3c3e55302997748359b9b7081>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a6caec4873f59befa70697c8fb180e501b7314cdf59d45b3b7a69ed9953d5123
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dea71925b69de424a8bb3c90ad5751f39c35df9e85ade437e6f6404b3ba12a42
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/25cacc3d5817e5a890774ce3f4d0fa12994a250b847c1c2d0f8722e2c454cd4d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e4e2db140c3425ea61cc01d83ac8efc6b68f64aa8fdee419d0f8da13a01e30cf
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:d0ab9b30cef75fe8c96ea80fa5f1e73cd8fd361307632fc1ea57cdf2c1bee43c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/84ccc300d580fb3de6b36fab26524b43da45e7213d205b57b9db715dc24d35f3>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6c19ef9b94965f9ad2eaad940fb63f9ca7e23b3ac440fad96886e12725d61c4a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/123e44ba5b6136da167d209b8d16a5509456d56bcfbd6779dde010a5a305cc0c>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/6f55c7250419fd7b00aefa818665acb069243d95219be598a962ae19e463fe56>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:bb491546f6a8a5822aa4d4b992f527315587c8a9f98e88128a91a6b568d13521
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c3fcd852d10a2a17df37ebb4bd3c94871856a3ae8644f96cd4e349b85265c9fc
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0dc1e53297c8c1621b570b7c1eb59c12deb7597f09a71aee7b3addcbc847d082>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2c80d772-5a21-4e9d-be8a-35e9bb6d66c6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4512ddf72ed62ab139cacd86871034a760c230160bbd136c29d8154f6f915ec1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a530640a086676bac0b61fa8cd746f745fea6eb99a2151b9760e4214f35464b5
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f7e5bf14510429f7bf7ead581fecd66761cb0606caf62747eb99f26c58718d81
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dbb530bd-a765-49e6-8c3e-4fed14d44c4e
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/58e5a98d0c1886f7a2586f9764771187cfc54e2d8fea0ee70561a7c9173f23f0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/49ec40b83c61a0a70b5574e757ed6d4e8169630f2ab5c4e022d8fb28b8cb0a79>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:b0fc02dd4566e616301e5d85adf6b87eca8421e663cf2dbc70c9bc9f835d502a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e2bf9406-8c70-4dda-bb88-5771480d9155
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/38c05fbb2a8f6d32ecbcbfea620a45d3b45b6f4a5da44f405b62eb1ca10e5697>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ba3bf570-b12b-4968-8d8d-9d1212e8076c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:debe5a67407f1d2501e4d068747798e1d38e5f3b570b5eab18fd2e383e495469
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d9c35f09-2a47-4ecf-b078-4cbe86ad8527
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:d1a274073309ad03daf4f45139e48d74f26a20f5935376004033cd1d0d40ee76
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e8291377-9218-430d-9800-9f47592890ab
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1d2d1bfee0392b33b27842b459ad79c92c838dc4357f3e45025f1e342d710cd2>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/0fcef44fd2fe177f4a92674f955d70378098c0e62479e953bf5930962b595b0b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/752fe276-80d6-4b1e-b83b-d4876d1efe5c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/29288f0ca7906536e4eaca09e9a12b258f91c41006fbc490eb6baa38eb958c8c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/782682349b24078a97dc181bdb7dc62fb2cabc072878fc75a29f4ed70c86250d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f06cc0f693ac44d63dffbb8573da4b1ae2777decbaa9f3252aa50987ae6ed28b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:bb58563c6b5d4ca1ebb32e72c137b9b9500369c6cd8a37d177ed6365bfd31484
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:dce9ffab7edf87d670ce7ec399084fc2e12c6b5bb300b865e87c5237beae4ae0
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/24904455b8208a966475e0f6eeb1af64e688779f30edf2e56f582fdc5907f082>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/52bda330e11552b586106748bf652e5dd41163670d5c4226b2c02bfa2f579946>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:caa03ffd9aeb74baf941d678e902fd41a8a8dd95398ef885694c72de63a1351e
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/097191c539cc02e6044671221f3ea0a8428c7fbc8dbdd5f38ee8f02ca51c6082>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/96ceb4cf-ece3-417d-914b-3e6eff293e6a>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f3f1598c1a9fb9e3666a3001004e4bfdb028da702bb8755655c0946597bb8ea4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/488938bd557800723290a816c51b471fff7f4918237a509f697973af6f509390>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/647fb5c1b431b2be6ea938673ebc10b794cb78fdf17afa3a0d58c14f5748785f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d8fdc087c67efbf317d7f12d6caafbafae2d3516b4dc2e430fd6a1927806112a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/89caf2681b8c28f2a15e656dcbd861b641a121843486525c692bd306cd69a665>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e2dfbd3a56dd87414968d7454dcfde193145e331ddcfc86fb48a9c79b5c0cef3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/749bbdaf-dd7a-45e1-8f2e-98b8834bc295>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/530dbb2c-a798-4cae-b42e-737b80b83b22>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/54f3abc210660046573af1b844779e5a2bc7110d8588e0b6ab3801aee5090173>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/81334af3-1b6f-4308-aca3-107121462d56>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8428cb9d-8370-4287-81ec-af72ca67c1f7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2e6bfd281967920ad0053864d0959e65d024dbec7b401c42d7b93cc9eab270b7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/322b6396c7548615f67db85da6128a083ee85ed07ec934d15fa971c46d0dce5b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/86471b9b89a1a536ecd59088cadfc51703fd66a4bb351c5dc370d3f71d20e3f8>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/531f08c0-65ac-4f47-ac15-066097ac5756>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/254bbfb6c31a668446c339c0996864d23c3fe129a5aa05e274b463cbbb4a4bc2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d17190b8c5cd15be8c7417dececcbf9a2410aaf83a5b639fc53cb130a1d1c602
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e65a70ecf702fb23f1447e234eab584fe788e9618fb7d52cd1d562718207b499
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:eb31eb0b167e34e43a47ba63cc7bfbbf8e13ce818ede2e7af7bd513b857c8751
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a2da321ebc3da96b2e852105861173fb3e38e9e17c32933bf08722286271e061
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b10b532baab5f7a5871225d12771993c71254d52f12f493006fac0131eeac75e
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a51132a6f95272627426b76a0c01b78ba9c52f693343b2af7243b0a39b6e73be
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:d5f337b96ec0d924addb4e754ad877545ed28ec1a9a96b6a33325e560e787bff
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a20c3dd6a449e3e934ac8e1ae35800d9e86b1286c4dd179da48fbb74068471d0
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/826f1b30776e0f506c1193f503c5f393d4a817af38e34aaa0a00abd33b7e5565>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/61479013af87a73a8c2e7d8bea3a0875f3ed91cdda8553f53032549e05940f9d>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/6d1c55e517fd1fdcae81e9f07f0875aa9c452bed279e635b94fbe00630e7ae73>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0b1af0370213e4b8ea5c3d5a2ccadcfce1149d092da47a3e447fe383050f9506>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ab3f8c38-cb76-43c7-b48f-4440441fe5f8
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4011a19f5548a3fb8530c29caa3863a690b5c12bf18729584c9c5bc56330df88>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/20c38bb2-ae01-44e5-acc4-9005c2b34cad>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d9103d0e0e81bebd9c1eadbc7ac77dc046117522d05aa944a25ad28c3acdfdd9
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1fded46e07b78fa4fb6d136f8dfcbdee86cd0d498aad54b1931e52fcaebf14b2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/50ede269-5c49-41cd-be68-ac135314019c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2176cd7bde027a98b1d3c2f81862327cb8b3fa0df3757ed432371530e743ad5b>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/4141ab8d-b1e1-4b38-832a-76b4dba20dc7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3d9b62f5f22241fa8ff72e0c4aa6ec1d354fd38eae781b4f8d026b58b3f63b65>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/30150105ca468d1b19386bec5f9e93b81ce2e4dd3874c0708727262fc3cc27e5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7ce1f0f5c038366c299ce12d116dca24163f67537f85740a2d3a0d0841898edf>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a31e8740057822d2fc8411fe2bcdd2b564de41ec7de1a27960550d7c3ba843ef
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c93809518f932c82745d5f02da87d95dba524198a8de8c83bb8853de5dbae1cc
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:cb1c6d91813d744a3b2a1ae44f0603134ef0f897e695b44da9a0a58953bc0f24
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0cbfce1ee17fb64428e643c966464a4c3411180b30c10cb22ff51184a08b5b37>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5dd2dc635e884a73e231eb391d00149a3ff4fe5d0c0bf1464d36e98146206b86>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/03e09c5e8596149d461b0f73d0fa47b07c7e85cf8664265ecfbec967ab5cf0d9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/22d517f8-1f7d-4ed1-9ef6-6bc266982af4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/064b86e028d3398fc236c6407b81a36b1c5298658d90d407e34035dabfc582dd>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:a33cb6e858ea9fdd5cc8a6f6f97850094ce8f312b961ec6bd775c3dc024e4801
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cce1926b-51ff-4b66-a702-ea985f1d250b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fc4ab3a9032d05f4f9adcee44f0186a552fbd8c769cd531a633bef83d0d1e631
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c9b690fb92e8f528768411647b5e952852a7302b95603fa794886cfa0992fcfe
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:ce333adebd6614199af610e487ba6a9c4c2ec6781e354b1b925d790572905efa
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ebc8589470b92ac994448573f072f7a0408e4ab893364ed118fd65537c3b9ed0
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2e8b8cd3e72418bac7bdf822bec41eaa712c58336bf6de8c247d75aa793fbfa7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/98b6959a1b0c0d279a04287baf77d310097e07640b43ea654da8012bc6cb77fe>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/67b25dc29ad301f607aed564241d318de74be7dc1ec15202a67111d7a86becf9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7eff2130-5462-4569-8098-29ceec9e6a22>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/6e163ed93509d81fff72ea3fee33318902f3e8b2aea9b1d6af02c5f555c5b925>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:abba9868f1b06e7a5b47e35340359288bdbf837ff854424dc3aeda3f3152b1ab
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e1c62a335d473a956bdb049814a4660bf89560ae71b8621f6e7bc20f545838d5
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ddaed83e-7327-4490-9a54-4f8c0bc6041a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b9203a8b05d488ae5418033e2de5d76cc9841d34bdd59228c1e61ff401de44b2
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b191613c33445abaaaebf0d82c2543a8b778f891554acf9c3b36166af8328e9f
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/71d7f475-1a66-4687-87d4-b417a05d30c5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:add2b19bd9f51b81800cc1e2f4fb91c33bbb9afd05a7275ae964c1ac391fe770
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5d55c0281e70d053158a06a7898bb3e1a89ed48cf111c4b6fc2a9502ebafcade>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5d616f95de98d8fcaf42d087dbf905a942ec98787e61bc9c816c451a76567dce>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1298cc0fec62af4dcaa86b44d43fe7e3ee3632247e66e8fccd87c0e5c7b7742f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d0ec3d07-a15c-4e04-bcbb-b05083262544
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:aa368412c2a6d17d41b78030f2914211a77e5cda29c673afc49bf4ac655bc913
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/68879e6b75b4072009eeec2168e663052710338ae2499814f9d74c7844888d1c>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:b7e07299d7acf9e78f802915227b243c31fc56eadfb575039b81fb871eec9755
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ef75a0af1692c0c9158d5b07e79b029a85ddebd63b2e73a9e9357ea225c11fb4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:a9b3046e-331e-4668-b5cc-2da7bb09e354
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3e85c22e16805e6b2aa95b700a7a98e33dd1fa5897cd0f1eba12750fc14b3db0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4b114b8e-11c5-4bc8-a3c2-4f5f05d7f430>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/78198698632b92fbbdc965e4c531c4e016e2fe3f10da95f885402c36365f98ae>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1f5a8fb186baaa65c28a2be115c2ac96d8a4a1fdcf87e4ef9344cf6e5253fe73>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2a9b3ce162341512bdfd86885bc3dd0149c19b47699c272dfd9c89b6b9d3ef96>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/559066ee63a3bbb4dbcaac93d9da15d9e81891e17e8a1d104a5ed356daa4aca4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/469298eac85cce8381c45c07c150cfaf104e55e465a2100155f802d105ee284b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5860ea2ba216c16175b4c02403537bf5ab9604bd78b5d46bbba3b21c2b657474>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/86b091345c1db7a6cc6f20c42bb48ac33955a5a0455b7bc04f0de2fb3428aa18>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5072fad918135764714007cea2f3573462199d6cbe7b96d6ac57d1c9b7bde399>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ecab54c1ed00982e4994d513a7c9b95e2f927b4a756474df1ff0d7f38dd523cd
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/49086436-b6c2-48f6-9a87-3096bd3a1783>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/05d2729c880f168ae0d1b46f001d4a5691a7de650ef2604e6213111898e7c427>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/65c4e7898d585670de7b93fbdf2fc3d9a1d032a5b9bf9bbb89cb15b46edcb6a5>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9b1af8b3306f7f2966d2326a7a301c149d2a62db4803335aaffae9ff45fe068d>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:fa31b871893350016e02634fed022edb4fd8d3a5da3290f0aca14371b5438537
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9c4b6ecab0caa8f191c64ff68c6a9784417e64d81ff93b75dfbe4dbf3ee814b0>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/62750c0093310bc293d1a89dd44abb34a1402e0ccb5b06f9f7e590d7dfe642ec>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/83e0d28b4ab2abdaf555b012e0d2ad3701f9fa71a196ece3697109ce0be5507b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/14cf807351ef2b7b20c8f481573b576f94cff8d7b8722190f137bc52a4d2e8c8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d7a3fb84986fb678bc6cfdc438f0c2279479d36a29cf93e55018c8c5de9eb640
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/386f7c72-1c2b-49ea-b9fa-664abf86d15f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:ba0cb87f-1502-4b68-bdea-b14b0c21b660
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:edc85ae64bd6a8ed73aa98750904f14dcb7e9445d4003f9e970db7a65a2076f4
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/972a983b83412a23886236a7f8a3c21bf6765879c4104ba9037199a7efe084d1>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/07432c31-b65f-4f31-b0f4-c9b5e84a20ef>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/76a649af4784166f6dec6079e6fa38acde4d860ab9133c955085018a7875b1c9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c4880f97bbca3e0d5cbdee8a3af11942b026c6f4bf1668e883850536f65e5a5a
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e852a0c8-e610-4359-9d8f-baa42e1bf5cf
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d6b1c96417814947db0b80c75246781b5f42fa34e49dfe190681f0188e7b660d
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c7491efa10d9054df49b02cdb0c59b4b80a0885adb18875a6e7a57794c3f8094
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/56f5706b531b57eacf30076d6f8c51a4653ab2f7173746e7a503cf784f2c1ef2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:fd9abc2a-e346-4bf4-bbfa-e1bba880e2b9
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f3e7f352-0c9a-41ab-8c16-b342e6357191
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/214481c1-31f0-4b85-a86b-856613cdda89>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c319a3c9388be82f10f5bf89734e4e83f713ea1d07f113e2f8ea946a232d2c30
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b77b75f239b9a14e40750981aa88976e46df7ddf83c3554103409a4a2291fea3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/186e802462653486cdce5fe867366e3f8ca32ef5737782fb835a4836c0308700>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/4640dcea6114e9c8069e3f7a0f6877c227a2eac6f2d4f18708e92b591e76aea6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e9ff7d76b21f3b53e43fe7309e52c25cdf09e8ad0462ac547dd3f95109de1dc5
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/318bea04b07639aa272697c32c98fb7c7d79e6f74264081003c223ea0ff2f925>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4ebe60dd-e9cf-449f-a3cb-e85c558149c1>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/37f67d5f7c88ef4193b7c68cb2d1dfc17a3ffb8ed5ec4af381d6e73a8ecb78d9>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6a178c83fcb1a0161b3ed62616eac8ea5442737d2d8259ed6f46e07c03241238>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d11728b8-28df-4483-98f2-6adef04854dd
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7e7f8451ed197bd8ac54233cea574387d9ddf7a13b2ddaa64fec753e105d8720>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/78764a89e722e6b4e68a777942a0a965ac2d1b7fc6f5916bd21f139e2e776198>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9805c75c20f76bbeae11240e0e51644d48a141a41d6ba2c2fe8a52eb8094894d>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b83436a463e3511f19f6fa8f3098e4daa433f3bc1dc16e5c08ed517500dbd53b
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5018524f9ceca4f9e21764f9e8e4e63d1ad6890c338c090d0dd074faccf1bfb2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4f452f5ad74a9cf4c6af447cb07157d8dad793abecff39729d7ab2eb582ec290>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/228a6eafda65209e5c9054dc08e3ed672b95a2538967d1cffce35b7452ac3dc6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/686e3c12c1be2a8ead91fca38652b40f11e3f62752631d6bbc6746d686f4f661>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f50eb6223ba7f58fb2734074efb10e811f49e47d2475d55d84ec3659851128ee
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7bb446534d60c38d4c8a04fa0ec2cc8f7b5109003e4470f5c0e9f6fcb96f72e7>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0f316807-839b-4554-a4d8-8656e9f83201>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0f90644a16f44a40288110c9e8417299eb84a4a850322737bc66df3b5edd83b6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cc641190ff45d4eee0f4934f2385565397018d91b361d6e8fae90f4763f311db
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d8cb6ca314f27d657f4043f27110632e63a9520070728922d3c958f51d70c281
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/4b291d8c-b200-4b07-9459-1651e5613cc4>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d8f884cfc2a2ee889280c64b665a52d5e7f75bf0237464f87737c2125c0489be
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c465b98a4eea9178a0922d138579bdd6ce78fe9a58c7ee8c906bcc992c17896c
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d71ddb7a663a892d7a8cb511d30bf5ae3ba49fda39dd65e39dae9c789bb901fe
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/6b15588f0dafa2227219b722d6e99de626ec0b4c6835a7a43416181059bc3c24>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/927c0e00-65db-4003-b3ef-715428141de8>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/458df2d318d52e34278e4ce1886b9458351d3a4b06fe28c68a7558b0cdd528c3>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:ce1d2c35aab153f16e0bb65ae972e992beb0ac3affc2d13c63433dcee8270407
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:d2fdedd90b3cb372feef6c39bf0e4ee8073cc9080bbb22814d2f490098811649
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e0b593eef5582d059f9735ab0b4c7b74ac6466f599f5c2dd960191d3545759f2
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cb2b3462564710878e32548ef95190daa0e154a43d6677ec85a548eaa23b4d12
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/3a6f5e9a-cb20-4388-b56c-0c05aeed3995>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6af38a22fcba9d1701a77d9c869e0f06e11a3291a71a4118a7cd93629ba92c27>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/03df783df9b22fa5340f962d439c46048ba62f6b4f43bd2497eca20db7cd8617>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e975ddd23d68827a667626b894112d8163050ab8d8495fa0be2639a5e05dd4fc
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b0da78eff1fb1952e35a5262c7faca2b73bef24bf9a3ed6af88496022678b3ff
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/94158248e8e9bd9a05012e06db794178caa74731b2dadcf84f5ad7373f13abcc>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/2a1f6d84-4c42-4e9c-805c-b99cb8a3b0fe>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/83d66d9bd034f307d179d611ef77ff9e705ce1d75c13cded299badd53d5213db>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0a0f52e2ece73e8f0bdfa4268ba47bea3e0d523fce943e1fb8927032563e065f>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/8ff4bc3e6e0af73e99f068bc0ed55b5e76791a6070d0722c7b0cc11af32120e9>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/1b2047de-fff3-4904-9450-c301fffd624f>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/774a7935dd8a262a5d0e9bed428a8999ccc2995aad2b154706322d4f5f2adff8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e7ff93ecd6ec0ad906e179e3ccb1cea698e30013e888fa28c725b272beef3b99
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:b51830c8c88c916b24621a3674f72ab5b0c2ba6d1a3678a4fd5bb64c9627dfc3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e9ea110ef3a9ffaad3be6670515a98b49f74e6827916eb962b72942c65efbec3
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:e452e23b-95cb-4b75-8825-503288ede636
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/5345fe3e-2a23-4f65-b531-1d8fa55ce217>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f6bc5285-df3f-413f-a349-30bf08d512b7
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f33d06a3505a89497193b17b76478804a24b6929fa8a57fb0de47e1a7300a31a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/7cce8da1cb80bed8ceccf5c076701e676543b7f01af9a57da9bd6d5324ad411c>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/9b39426aff444e213ddd91949dc97f3693ebe863f39cb60a57c1b8948d04ee62>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b54baac8-fcbf-426b-8407-542cdc009fee
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:c6f0bca7de9ab3b73cb12cbe2332e5f7e7e5d9850966c49e7319ee78d876b76a
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:cec59e5e872a9084e93becf3026bfcc2f25926ea76372711b7a745875f3b7949
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/6ad4129b8c8787eca3b2f943a37ffbb3530b0a17111bb5cb95322bee40563788>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/3a12adea-221a-4a11-8961-3503598bbaf7>
+	ns0:orgStatus	ns1:abf4fee82019f88cf122f986830621ab .
+<http://data.lblod.info/id/bestuurseenheden/09ecb404-180e-456f-bf1b-684e90a69427>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/0024ad40392dff253a4dbd1485054d187640af58d2ed4210140ad6cc651305db>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0f8bb88e65741fd046d2f2c5542c96a14a42cfe1228d1b1387bb0441b33a6fb1>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/0855d794d31887234a3edfede8cc68dbe7a177c9beba03c884d443177e9d5287>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/079159c373e29e05221c4338a2440e4f58ddababa1d8f94dedf792b5414baf61>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/03c466beb217e884d90f62a2d78674cf6403c2671f9b4517e1aa8b93ed8aa41b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/10a87c515116086d4a849d83d5105bab3ad17cdbc42f7c8b1d43e4d30d253db2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/0331f7d9259900c12c7cd16e081dca917d6b3ceda358cf69f12a1cdbb734b9ac>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/005f263d440315a440c47a34fddec33b7745836d64fe0b033fc82957285e838b>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/02c2bc6e15785114f5526b1ab5d29c6049e664bc6a5fab8bb27ae75ac4ad25c2>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/049665d9c354c0eaf41c2f9fb74343ba2090ad02c4871d3a95d5e29ecb91d3ba>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/153385e2ad0fa836180c3d91c06541f01e517dc929dd7afc7f3fa8d2f4d694a8>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/1c9c7c70aa6408fc6f63c487eaea167fbc8eceda2aef2d7dff8c89dd2317f431>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:b206763c-d8d2-45bd-ba1b-b5462bdd823c
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e0d71bad-4684-4796-9f76-c3babb972a0f
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:cec30867-e378-4e86-9568-1efebb6ccd7d
+	ns0:orgStatus	ns1:abf4fee82019f88cf122f986830621ab .
+<http://data.lblod.info/id/bestuurseenheden/3deaa042-58f3-474f-abc2-9cb3e15f4221>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/863673c6-7bc9-4bbd-a42a-9ef1d2dc4c05>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/5202c9ba-40fb-44e2-8116-6eceadc1e60a>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/70285c2d-2045-414e-bd49-56155a736e56>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8e448f7f-5a1d-44b0-a99d-274b2cc66f58>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/99509194-025b-4292-9add-aa98b4867350>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/2908c8ed-0f67-44c0-b69e-5a8b07238d15>
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:b25f4408-0b7c-46d0-a234-0936cac4eb7c
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+<http://data.lblod.info/id/bestuurseenheden/8d6609b4-1a20-46b8-97ed-150c6d53acd6>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+ns2:f4228a39-de89-4a50-925f-d5d8d5109e79
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:b81fdc5f-d1ba-49f2-831f-ed549ad94394
+	ns0:orgStatus	ns1:d02c4e12bf88d2fdf5123b07f29c9311 .
+ns2:e0920e46-85b9-4736-a906-b254cc7f1855
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/677E959629299CC832892A24>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/81dd243d-f66c-4157-b105-5407aa83cb62>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+<http://data.lblod.info/id/bestuurseenheden/671B9AEA4FB29391F9A62762>
+	ns0:orgStatus	<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .

--- a/config/migrations/2025/20250114112818-import-organisation-statuses/20250114135204-import-organisation-statuses--copy-organisation-status-data-to-public-graph.sparql
+++ b/config/migrations/2025/20250114112818-import-organisation-statuses/20250114135204-import-organisation-statuses--copy-organisation-status-data-to-public-graph.sparql
@@ -1,0 +1,20 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?org regorg:orgStatus ?status.
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/public> {
+     ?org a besluit:Bestuurseenheid.
+   }
+  GRAPH <http://mu.semte.ch/graphs/temporary-organization-status> {
+    ?org regorg:orgStatus ?status.
+  }
+}
+
+;
+
+# Remove temporary graph
+CLEAR GRAPH <http://mu.semte.ch/graphs/temporary-organization-status>


### PR DESCRIPTION
For new functionality, LPDC requires status information for organisations. This PR imports this data from OP, which the master for that data.

## Proposed solution
The concept scheme and concepts for organisation statuses were exported from OP (PROD) using the following query (the retrieved URIs `?s` were manually determined):

``` sparql
CONSTRUCT {
  ?s ?p ?o.
} WHERE {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s ?p ?o.
  }
  VALUES ?s {
    <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>
    <http://lblod.data.gift/concepts/abf4fee82019f88cf122f986830621ab>
    <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>

    <http://lblod.data.gift/concept-schemes/b8dcb04f0d1feb86ff01cc0677363b20>
  }
}
```

The actual organisation statuses are also exported from OP (PROD) using the following query:

``` sparql
PREFIX regorg: <http://www.w3.org/ns/regorg#>
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
CONSTRUCT {
  ?org regorg:orgStatus ?status.
} WHERE {
  GRAPH ?g {
    ?org a besluit:Bestuurseenheid.
  }
  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
    ?org regorg:orgStatus ?status.
  }
  VALUES ?g {
    <http://mu.semte.ch/graphs/administrative-unit>
    <http://mu.semte.ch/graphs/shared>
  }
}
```

The resulting Turtle migration inserts this data in a new, temporary graph. Finally, another migration copies the status triples for which LPDC has a resource in its public graph to that public graph. Afterwards the temporary graph is cleared.

## Notes
- About 24 organisations (exact number depends on which environment's data you use) will not have a status since these organisations are not in OP. Most of these are organisations that are not actively used, and will be treated the as "Not active" organisations.
- For the moment, this status will only be used to perform some additional validations on product instances when a user wants to publish them. The status information will not be shown in the frontend or anything, so no changes are done to the frontend or the data model.
- The actual new functionality using this data will be implemented as a separate PR for the `lpdc-management-service`. Background information can be found in the related tickets.

## Related tickets
- LPDC-1340
- LPDC-1355 describes the new functionality for which this data is needed