### PR TITLE
feat: consume LDES from BCT to integrate additional organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 ## Unreleased
+### Backend
+- Add an LDES consumer for BCT to support additional integrating organisations  [LPDC-1324]
+### Deploy instructions
+- To enable the LDES consumer for BCT set the correct `LDES_ENDPOINT_VIEW` in the environment's `docker-compose.override.yaml`. Ensure the migration adding data to the authorisation graph is executed before starting the LDES consumer.
+#### Docker commands
+- `drc restart migrations; drc logs -ft --tail=200 migrations`
+- `drc pull ldes-consumer-instancesnapshot-bct; drc up -d ldes-consumer-instancesnapshot-bct`
 
 ## v0.24.0 (2025-02-10)
 ### Backend

--- a/config/migrations/2025/20250204101958-insert-authorization-new-integrating-municipalities.sparql
+++ b/config/migrations/2025/20250204101958-insert-authorization-new-integrating-municipalities.sparql
@@ -1,0 +1,13 @@
+PREFIX lpdc: <http://data.lblod.info/vocabularies/lpdc/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/authorization> {
+       ?organisation lpdc:canPublishInstanceToGraph <http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/bct>.
+  }
+} WHERE {
+  VALUES ?organisation {
+    <http://data.lblod.info/id/bestuurseenheden/8d7de878-db13-4fe1-8d74-bb8c9a690d90> # Pelt (municipality)
+    <http://data.lblod.info/id/bestuurseenheden/fad1ca7a-ac26-43fc-b167-b8ae4f873553> # Pelt (OCMW)
+    <http://data.lblod.info/id/bestuurseenheden/764278b3ceac360476b418c108d1b022b6e0cc8fb676f3f6b6b9faf78a2375ba> # Geel (gemeente)
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,3 +297,23 @@ services:
       - virtuoso:database
     restart: always
     logging: *default-logging
+  ldes-consumer-instancesnapshot-bct:
+    image: redpencil/ldes-consumer:feature-rdf-connect-ldes-client
+    depends_on:
+      lpdc-management:
+        condition: service_healthy
+      migrations:
+        condition: service_healthy
+    volumes:
+      - ./data/ldes-consumer-instancesnapshot-bct:/data
+    environment:
+      LDES_ENDPOINT_VIEW: "<endpoint first page of ldes stream>"
+      MU_APPLICATION_GRAPH: "http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/bct"
+      PERSIST_STATE: false
+      REPLACE_VERSIONS: false
+    labels:
+      - "logging=true"
+    links:
+      - virtuoso:database
+    restart: always
+    logging: *default-logging


### PR DESCRIPTION
A new organisation will be integrating with LPDC to allow their clients to manage product instances via their application. This PR sets up LPDC's end to consume the new LDES provided by this organisation.

## How to test:
Configure the correct LDES stream endpoint in `docker-compose.override.yml`, for the DEV and TEST environments this is:

``` yaml
ldes-consumer-instancesnapshot-bct:
  environment:
    LDES_ENDPOINT_VIEW: "https://igenservicedev.licquid.com/LPDC/v1/InstanceSnapshot?pageNumber=0"
    CRON_PATTERN: "*/2 * * * *" # or whatever cronpattern suits your needs
```
- Make sure the migration in PR has executed by (re)starting the migrations service
- Boot the (rest of the) stack and check whether
  - the `ldes-consumer-instancesnapshot-bct` service consumes the LDES feed correctly; and
  - the `lpdc-management` picks up the new snapshot instances and merges them to the right product instances.

## Notes
- The authorised organisations added by the migration are those currently used for testing. The final list (for PROD) will include all clients for BCT.
- A tagged version of the LDES consumer is underway, see the [PR](https://github.com/redpencilio/ldes-consumer-service/pull/45) for more information.

## Related tickets
- LPDC-1324