### PR TITLE
feat: bump images and set feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## Unreleased
+### Backend
+- Bump `frontend` and `lpdc-management` to add the merger feature flag (LPDC-1339)
 
 ## v0.25.1 (2025-02-25)
 ### Backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   lpdc:
-    image: lblod/frontend-lpdc:0.19.0
+    image: lblod/frontend-lpdc:0.19.1
     environment:
       EMBER_ACMIDM_SCOPE: "openid rrn profile vo abb_lpdc"
       # The next variables are environment-specific
@@ -18,6 +18,7 @@ services:
       EMBER_ACMIDM_LOGOUT_URL: "<ACMIDM_LOGOUT_URL>"
       EMBER_ACMIDM_AUTH_REDIRECT_URL: "<ACMIDM_AUTH_REDIRECT_URL>"
       EMBER_ACMIDM_SWITCH_REDIRECT_URL: "<ACMIDM_SWITCH_REDIRECT_URL>"
+      EMBER_FUSIES: "false"
     links:
       - identifier:backend
     labels:
@@ -209,7 +210,7 @@ services:
     depends_on:
       migrations:
         condition: service_healthy
-    image: lblod/lpdc-management-service:0.46.2
+    image: lblod/lpdc-management-service:0.46.3
     environment:
       LOG_SPARQL_ALL: "false"
       LOG_SPARQL_QUERIES: "false"
@@ -222,6 +223,7 @@ services:
       MU_APPLICATION_GRAPH: "http://mu.semte.ch/application"
       INSTANCE_SNAPSHOT_PROCESSING_CRON_PATTERN: "*/1 * * * *" # run the job every minute
       CONCEPT_SNAPSHOT_PROCESSING_CRON_PATTERN: "*/1 * * * *" # run the job every minute
+      ENABLE_MUNICIPALITY_MERGER_FLAG: "true"
     labels:
       - "logging=true"
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
 
 services:
   lpdc:
-    image: lblod/frontend-lpdc:0.19.1
+    image: lblod/frontend-lpdc:0.20.0
     environment:
       EMBER_ACMIDM_SCOPE: "openid rrn profile vo abb_lpdc"
       # The next variables are environment-specific
@@ -210,7 +210,7 @@ services:
     depends_on:
       migrations:
         condition: service_healthy
-    image: lblod/lpdc-management-service:0.46.3
+    image: lblod/lpdc-management-service:0.47.0
     environment:
       LOG_SPARQL_ALL: "false"
       LOG_SPARQL_QUERIES: "false"


### PR DESCRIPTION
## ID 

LPDC-1339

## Description

Fusies will no longer be needed (for now), but will be in the future. Which is why this PR uses a feature flag to show / hide code about the fusies:

- 'Sorteren en filteren': the fusies filter should not be showing anymore
- The fusies pill in the table should not be showing anymore
- The copy button should now directly copy, and not open a popup to choose between fusie and regular

This PR bumps the needed images, and sets their feature flags
