### PR TITLE
fix: do not use cache on route for public service concepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ## Unreleased
 ### Backend
 - Bump `frontend` and `lpdc-management` to add the merger feature flag (LPDC-1339)
+- Disable cache on public service concepts route [LPDC-1360]
+#### Docker commands
+- `drc pull lpdc lpdc-management; drc up -d lpdc lpdc-management`
+- `drc restart dispatcher`
+
 
 ## v0.25.1 (2025-02-25)
 ### Backend

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -117,8 +117,15 @@ defmodule Dispatcher do
   #################################################################
   # Public Services - LPDC-IPDC
   #################################################################
+
+  # NOTE (11/03/2025): Do *not* use cache in the following rule. When a user
+  # creates a new product instance from a concept, the management service can
+  # update the `conceptIsNew` and `conceptIsInstantiated` properties for the
+  # corresponding concept display configurations. These updates are not picked
+  # up by the cache, resulting in the frontend showing outdated information
+  # afterwards. (See LPDC-1370)
   match "/conceptual-public-services/*path" do
-    forward conn, path, "http://cache/conceptual-public-services/"
+    forward conn, path, "http://resource/conceptual-public-services/"
   end
 
   match "/identifiers/*path" do


### PR DESCRIPTION
## Summary
When a user creates a new product instance from a concept, the management
service can update the `conceptIsNew` and `conceptIsInstantiated` properties for
the corresponding concept display configurations. These updates are not picked
up by the cache, resulting in the frontend showing outdated information
afterwards.

## Proposed solution
Bypass the `mu-cache` service for public service and go directly via the
resources service for public service concepts. This is how it worked before #32.

## How to reproduce the bug
1. Log in as some organisation in LPDC, any should do.
2. Create a new product using the "+ Product of dienst toevoegen" button in the
   top-right corner.
3. In the concept table on the next page, select a concept with a green "Nieuw"
   pill behind its name.
4. Take note of the name of the concept.
5. Create a new product instance using the "+ Voeg toe" button in the top-right
   corner of the concept preview page.
6. Go back to the product instance overview page, for example by clicking the
   "Lokale Producten- en Dienstencatalogus" link in the breadcrumb at the top of
   the page.
7. Create another new product using the "+ Product of dienst toevoegen" button
   in the top-right corner.
8. In the table of concepts, look for the concept for which you previously
   created a product instance. The intended functionality is that the green
   "Nieuw" pill changed into a grey "Toegevoegd" pill. Due to the bug this will
   not have happened and the concept still shows a green "Nieuw" pill despite
   that a product instance was just created for it.

## How to test
1. (re)start the `dispatcher` service with the updated configuration in this
   branch.
2. Repeat the steps in the previous section and verify the bug no longer occurs.

## Related tickets
- LPDC-1370