### PR TITLE
chore: bump LDES consumer to tagged version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ### Backend
 - Bump `frontend` and `lpdc-management` to add the merger feature flag (LPDC-1339)
 - Disable cache on public service concepts route [LPDC-1360]
+- Bump the BCT LDES consumer to a tagged version
 #### Docker commands
 - `drc pull lpdc lpdc-management; drc up -d lpdc lpdc-management`
 - `drc restart dispatcher`
+- `drc pull ldes-consumer-instancesnapshot-bct; drc up -d ldes-consumer-instancesnapshot-bct`
 
 
 ## v0.25.1 (2025-02-25)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -300,7 +300,7 @@ services:
     restart: always
     logging: *default-logging
   ldes-consumer-instancesnapshot-bct:
-    image: redpencil/ldes-consumer:feature-rdf-connect-ldes-client
+    image: redpencil/ldes-consumer:0.9.0
     depends_on:
       lpdc-management:
         condition: service_healthy


### PR DESCRIPTION
The LDES consumer was previously use was based on a feature branch. This branch has been merged and a new tagged version of the LDES consumer has been released. The only difference between the previously deployed version and the released one are some edits in the README.