### PR TITLE
fix: link organisations to NUTS2024 spatials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 - Disable cache on public service concepts route [LPDC-1360]
 - Bump the BCT LDES consumer to a tagged version
 - Bump `lpdc-managament` adding extra validations on incoming instance snapshots [LPDC-1301]
+- datafix: link active organisations to new spatials [LPDC-1383]
 #### Docker commands
 - `drc pull lpdc lpdc-management; drc up -d lpdc lpdc-management`
 - `drc restart dispatcher`
 - `drc pull ldes-consumer-instancesnapshot-bct; drc up -d ldes-consumer-instancesnapshot-bct`
+- `drc restart migrations; drc logs -ft --tail=200 migrations`
 
 
 ## v0.25.1 (2025-02-25)

--- a/config/migrations/2025/20250325140456-fix--link-organisations-to-nuts2024-spatials.sparql
+++ b/config/migrations/2025/20250325140456-fix--link-organisations-to-nuts2024-spatials.sparql
@@ -1,0 +1,63 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX time: <http://www.w3.org/2006/time#>
+PREFIX nuts:  <http://data.europa.eu/nuts/code/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?werkingsgebied skos:exactMatch ?oldSpatial.
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?werkingsgebied skos:exactMatch ?newSpatial.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?org regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>; # Active
+         besluit:werkingsgebied ?werkingsgebied.
+    ?werkingsgebied skos:exactMatch ?oldSpatial.
+    ?spatial time:hasEnd ?endDate.
+    FILTER (?endDate = "2024-12-31"^^xsd:date)
+  }
+  VALUES (?oldSpatial ?newSpatial) {
+    # Galmaarden (BE24123023) + Gooik (BE24123024) + Herne (BE24123032) -> Pajottegem (BE24123106)
+    (nuts:BE24123023 nuts:BE24123106)
+    (nuts:BE24123024 nuts:BE24123106)
+    (nuts:BE24123032 nuts:BE24123106)
+    # Ruiselede (BE25737012) + Wingene (BE25737018) -> Wingene (BE25737021)
+    (nuts:BE25737012 nuts:BE25737021)
+    (nuts:BE25737018 nuts:BE25737021)
+    # Meulebeke (BE25737007) + Tielt (BE25737015) -> Tielt (BE25737022)
+    (nuts:BE25737007 nuts:BE25737022)
+    (nuts:BE25737015 nuts:BE25737022)
+    # De Pinte (BE23444012) + Nazareth (BE23444048) -> Nazareth-De Pinte (BE23444086)
+    (nuts:BE23444012 nuts:BE23444086)
+    (nuts:BE23444048 nuts:BE23444086)
+    # Lochristi (BE23444034) + Wachtebeke (BE23444073) -> Lochristi (BE23444087)
+    (nuts:BE23444034 nuts:BE23444087)
+    (nuts:BE23444073 nuts:BE23444087)
+    # Lokeren (BE23646014) + Moerbeke (44045) -> Lokeren (BE23646029)
+    (nuts:BE23646014 nuts:BE23646029)
+    (nuts:BE23444045 nuts:BE23646029)
+    # Melle (BE23444040) + Merelbeke (44043) -> Merelbeke-Melle (BE23444088)
+    (nuts:BE23444040 nuts:BE23444088)
+    (nuts:BE23444043 nuts:BE23444088)
+    # Beveren (BE23646003) + Kruibeke (BE23646013) + Zwijndrecht (BE21111056) -> Beveren-Kruibeke-Zwijndrecht (BE23646030)
+    (nuts:BE23646003 nuts:BE23646030)
+    (nuts:BE23646013 nuts:BE23646030)
+    (nuts:BE21111056 nuts:BE23646030)
+    # Bilzen (BE22373006) + Hoeselt (BE22373032) -> Bilzen-Hoeselt (BE22373110)
+    (nuts:BE22373006 nuts:BE22373110)
+    (nuts:BE22373032 nuts:BE22373110)
+    # Borgloon (BE22373009) + Tongeren (BE22373083) -> Tongeren-Borgloon (BE22373111)
+    (nuts:BE22373009 nuts:BE22373111)
+    (nuts:BE22373083 nuts:BE22373111)
+    # Ham (BE22171069) + Tessenderlo (BE22171057) -> Tessenderlo-Ham (BE22171071)
+    (nuts:BE22171069 nuts:BE22171071)
+    (nuts:BE22171057 nuts:BE22171071)
+    # Hasselt (BE22171022) + Kortessem (BE22373040) -> Hasselt (BE22171072)
+    (nuts:BE22171022 nuts:BE22171072)
+    (nuts:BE22373040 nuts:BE22171072)
+  }
+}


### PR DESCRIPTION
As part of the 2025 municipality mergers several spatials became invalid as
their municipalities were involved in a merger. For active organisations we
update their werkingsgebieden to link to the new, unexpired spatials. This way
the correct, unexpired spatial is added as geographical area when those
organisations create new product instances.

## How to test
1. Log in to LPDC as one of the affected organisations, for example Lochristi or
   Tongeren-Borgloon (municipality or OCMW should not matter)
2. Create a new product instance using the "+ Product of dienst toevoegen"
   button
3. Either create a completely new product instance using the "+ Volledig nieuw
   product toevoegen" button. or select a concept from the table and use the "+
   Voeg toe button" to create a new product instance
4. In the properties tab (*nl. Eigenschappen*) the geographic area
   (*nl. Geografisch toepassingsgebied*) should be automatically filled in with
   the spatial matching the merge municipality.
5. When trying to publish the new product instance you should **not** get an
   error about the geographic area. You may get other errors depending on the
   (lack of) contents of other fields.

Something like the following query can be used to list all affected
organisations (results in 16 organisations on the TEST environment):

``` sparql
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
PREFIX regorg: <http://www.w3.org/ns/regorg#>
PREFIX time: <http://www.w3.org/2006/time#>

SELECT DISTINCT ?name ?class ?nutsLabel ?end
WHERE {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s besluit:werkingsgebied ?werkingsgebied;
       skos:prefLabel ?name;
       besluit:classificatie/skos:prefLabel ?class;
       regorg:orgStatus ?status.
    FILTER (?status = <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>) # Active
    ?werkingsgebied skos:exactMatch ?nuts.
    ?nuts time:hasEnd ?end;
          skos:prefLabel ?nutsLabel.
  }
} ORDER BY ?nutsLabel ?name ?class
```

## Notes
- I opted to limit changes to active organisations to avoid changing the linked
  werkingsgebied for municipalities (and OCMWs) that became inactive as part of
  the mergers.

## Related tickets
- LPDC-1383