### PR TITLE
chore: reset municipality merger labels on product instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 ## Unreleased
+### Backend
+- datafix: disable municipality merger labels for product instances [LPDC-1403]
+### Deploy notes
+#### Docker instructions
+- `drc restart migrations; drc logs -ft --tail=200 migrations`
 
 ## v0.26.1 (2025-04-04)
 ### Backend

--- a/config/migrations/2025/20250403092249-chore--reset-municipality-merger-labels.sparql
+++ b/config/migrations/2025/20250403092249-chore--reset-municipality-merger-labels.sparql
@@ -1,0 +1,22 @@
+PREFIX ipdc-lpdc: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
+
+DELETE {
+  GRAPH ?g {
+    ?productInstance ipdc-lpdc:forMunicipalityMerger "true"^^xsd:boolean.
+  }
+} INSERT {
+  GRAPH ?g {
+    ?productInstance ipdc-lpdc:forMunicipalityMerger "false"^^xsd:boolean.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?productInstance a ipdc-lpdc:InstancePublicService;
+                     ipdc-lpdc:forMunicipalityMerger "true"^^xsd:boolean.
+  }
+
+  FILTER
+  (
+   STRSTARTS(STR(?g), "http://mu.semte.ch/graphs/organizations/") &&
+   STRENDS(STR(?g), "/LoketLB-LPDCGebruiker")
+   )
+}


### PR DESCRIPTION
The municipality merger label was hidden for the users by putting its functionality behind a feature flag. This migrations resets the label to its default value for all product instances where it was enabled by users.

## How to test
- Follow the instruction added to the changelog
- You can check the data with using a query like below. In essence the result should be that the `forMunicipalityMerger` for all product instances should be set to false.

``` sparql
PREFIX ipdc-lpdc: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>

SELECT DISTINCT ?o COUNT(?s)
WHERE {
  GRAPH ?g {
    ?s ipdc-lpdc:forMunicipalityMerger ?o.
  }
}

```

## Related tickets
- LPDC-1403