### PR TITLE
fix: ensure all elements in IPDCOrganisaties concept scheme are concepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 ## Unreleased
+### Backend
+- datafix: ensure all resources in IPDCOrganisaties concept scheme have the type `skos:Concept`
+### Deploy notes
+#### Docker commands
+- `drc restart migrations; drc logs -ft --tail=200 migrations`
 
 ## v0.26.0 (2025-03-28)
 ### Frontend

--- a/config/migrations/20250404082955-fix--add-concept-type-to-all-ipdcorganisaties.sparql
+++ b/config/migrations/20250404082955-fix--add-concept-type-to-all-ipdcorganisaties.sparql
@@ -1,0 +1,12 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a skos:Concept.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s skos:inScheme <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties>.
+    FILTER NOT EXISTS { ?s a skos:Concept. }
+  }
+}


### PR DESCRIPTION
Not all resources in the IPDCOrganisaties[^1] concept scheme have as type
`skos:Concept`. This causes a query in the management service[^2] to report
inconsistent results. This in turn can lead to false positives when validating
the competent and executing authorities in product instances and product instance snapshots.

## How to test
- Follow the instructions in the changelog
- Check whether all elements in the IPDCOrganisaties concept scheme have the type `skos:Concept`. Example query that can be used:

``` sparql
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

SELECT DISTINCT count(?s)
WHERE {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s skos:inScheme <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties>.
    FILTER NOT EXISTS { ?s a skos:Concept. }
  }
}
```

[^1]: <https://productencatalogus.data.vlaanderen.be/id/conceptscheme/IPDCOrganisaties>
[^2]: https://github.com/lblod/lpdc-management-service/blob/development/src/driven/persistence/code-sparql-repository.ts#L19