### PR TITLE
Delete triples with empty values for contact point URL or address box number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - added the competency and executing level to all the orgs with a migration [LPDC-1278]
 - Bump `frontend` and `lpdc-management` to add validation before saving between authority levels and authorities [LPDC-1278]
 - Additional reports to monitor for authorities without levels [LPDC-1393]
+- datafix: delete triples with empty values for contact point URLs and address box numbers [LPDC-1297]
 ### Deploy notes
 - On ACC and PROD: bump the frontend version for the `controle` service in `docker-compose.override.yml`
 #### Docker instructions

--- a/config/migrations/2025/20250416133525-fix--delete-blank-urls-for-contact-points.sparql
+++ b/config/migrations/2025/20250416133525-fix--delete-blank-urls-for-contact-points.sparql
@@ -1,0 +1,18 @@
+PREFIX schema: <http://schema.org/>
+PREFIX ipdc-lpdc: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
+PREFIX euro: <http://data.europa.eu/m8g/>
+
+DELETE {
+  GRAPH ?g {
+    ?contactPoint schema:url ?url .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?instance a ipdc-lpdc:InstancePublicService ;
+                euro:hasContactPoint ?contactPoint .
+    ?contactPoint a schema:ContactPoint ;
+                  schema:url ?url .
+    FILTER REGEX(STR(?url), "^\\s*$")
+  }
+  FILTER (STRSTARTS(STR(?g), "http://mu.semte.ch/graphs/organizations/"))
+}

--- a/config/migrations/2025/20250416135555-chore--delete-empty-box-numbers-for-addresses.sparql
+++ b/config/migrations/2025/20250416135555-chore--delete-empty-box-numbers-for-addresses.sparql
@@ -1,0 +1,20 @@
+PREFIX schema: <http://schema.org/>
+PREFIX ipdc-lpdc: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
+PREFIX euro: <http://data.europa.eu/m8g/>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+
+DELETE {
+  GRAPH ?g {
+    ?address adres:Adresvoorstelling.busnummer ?boxNumber .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s a ipdc-lpdc:InstancePublicService ;
+       euro:hasContactPoint ?contactPoint .
+    ?contactPoint a schema:ContactPoint ;
+                  ipdc-lpdc:address ?address .
+    ?address adres:Adresvoorstelling.busnummer ?boxNumber .
+    FILTER REGEX(STR(?boxNumber), "^\\s*$")
+  }
+  FILTER (STRSTARTS(STR(?g), "http://mu.semte.ch/graphs/organizations/"))
+}


### PR DESCRIPTION
Add two migrations to slightly improve the data quality for LPDC. More specifically, this removes URLs for contact points for product instances that are empty strings or contain only whitespace characters. Similarly, box numbers for contact point addresses that contain only whitespace characters are deleted.

This data was most likely added to LPDC when it has less strict validations.

## Notes
- I opted not to remove similar triples for published product instances[^1]. This would require re-publishing the right versions, introducing additional complications. This complexity does not seem worth it since IPDC processes these blank triple values fine and removing the triples for product instance resources is sufficient for LPDC.
- The ticket contains some further discussion about other URL fields that have corresponding triples with empty strings. Since these do not cause any unexpected behaviour and to avoid possible side-effects it was decided not to remove these triples after all.

## How to test
### Empty contact point URL
0. Load PROD data into you local LPDC stack
1. Launch LPDC and mock-log in as municipality Roosdaal (or another organisation that is affected)
2. Select a product instance, any should do
3. For an already publish product instance, re-open it for editing using "Product opnieuw bewerken" button in the top-right corner.
4. Scroll down to the "Conctactpunten" section
5. If necessary, add a new contact point using the "Voeg contactpunt toe"
6. Click the "Website URL" field, after running the migration there should be no selectable blank line anymore.

Before:
![2025-04-16-173602_790x183_scrot](https://github.com/user-attachments/assets/c016a2f8-a8f5-46f7-b80c-dbffc1a81ada)


After:
![2025-04-16-173027_793x199_scrot](https://github.com/user-attachments/assets/3e80bccd-6909-4520-aee5-750fd853ccc8)

### Empty address box number
Business reported at least one user ran into issues with this where they got an error message that the address was invalid, while the address validation said it was okay. Supposedly, the users was able to solve it by removing the space in the box number field. But I was unable to reproduce the reported behaviour, so have no steps to follow here.

You can query the actual data in the triplestore to see whether the migration worked. For instance, with something like the following query:

``` sparql
PREFIX schema: <http://schema.org/>
PREFIX ipdc-lpdc: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
PREFIX euro: <http://data.europa.eu/m8g/>
PREFIX adres: <https://data.vlaanderen.be/ns/adres#>

SELECT count(DISTINCT ?address)
WHERE {
  GRAPH ?g {
    ?s a ipdc-lpdc:InstancePublicService ;
       euro:hasContactPoint ?contactPoint .
    ?contactPoint a schema:ContactPoint ;
                  ipdc-lpdc:address ?address .
    ?address adres:Adresvoorstelling.busnummer ?boxNumber .
    FILTER REGEX(STR(?boxNumber), "^\\s*$")
  }
  FILTER (STRSTARTS(STR(?g), "http://mu.semte.ch/graphs/organizations/"))
}
```

## Related tickets
- LPDC-1397
- LPDC-1394 (original incident report)


[^1]: Resources of type `ipdc-lpdc:PublishedInstancePublicServiceSnapshot`