### PR TITLE
chore: bump LDES consumer for Ghent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,18 @@
 - Bump `frontend` and `lpdc-management` to add validation before saving between authority levels and authorities [LPDC-1278]
 - Additional reports to monitor for authorities without levels [LPDC-1393]
 - datafix: delete triples with empty values for contact point URLs and address box numbers [LPDC-1297]
-- bump BCT LDES consumer to new version [LPDC-1414]
+- bump BCT and Ghent LDES consumer to new version [LPDC-1414]
 ### Deploy notes
 - On ACC and PROD: bump the frontend version for the `controle` service in `docker-compose.override.yml`
+- On TEST and PROD: In the `docker-compose.override.yml` for `ldes-consumer-instancesnapshot-gent`, remove the `LDES_STREAM` entry, rename `LDES_LOGGING_LEVEL` to `LOG_LEVEL`, and update `LDES_ENDPOINT_VIEW` to
+  + TEST: "https://ldes.qa.stad.gent/ldes/lpdc/by-page"
+  + PROD: "https://ldes.stad.gent/ldes/lpdc/by-page"
 #### Docker instructions
 - `drc restart migrations; drc logs -ft --tail=200 migrations`
 - `drc pull lpdc lpdc-management; drc up -d lpdc lpdc-management`
 - `drc pull report-generation; drc up -d report-generation`
 - `drc pull ldes-consumer-instancesnapshot-bct; drc up -d ldes-consumer-instancesnapshot-bct`
+- `drc pull ldes-consumer-instancesnapshot-gent; drc up -d ldes-consumer-instancesnapshot-gent`
 
 ## v0.26.1 (2025-04-04)
 ### Backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,19 +279,19 @@ services:
     logging: *default-logging
 
   ldes-consumer-instancesnapshot-gent:
-    image: redpencil/ldes-consumer:feature-stability-improvements-r1.1
+    image: redpencil/ldes-consumer:0.9.1
     depends_on:
       lpdc-management:
         condition: service_healthy
       migrations:
         condition: service_healthy
+    volumes:
+      - ./data/ldes-consumer-instancesnapshot-gent:/data
     environment:
-      LDES_STREAM: "<endpoint ldes stream>"
       LDES_ENDPOINT_VIEW: "<endpoint first page of ldes stream>"
-      LDES_LOGGING_LEVEL: "debug"
       MU_APPLICATION_GRAPH: "http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/gent"
-      SAVE_ALL_VERSIONS_IGNORING_TIMESTAMP_DATA: "true"
-      REPLACE_VERSIONS: "false" # we query snapshots. snapshots don't change ...
+      PERSIST_STATE: true
+      REPLACE_VERSIONS: false # we query snapshots. snapshots don't change ...
       CRON_PATTERN: "*/2 * * * *" # run the job every 2 minutes
     labels:
       - "logging=true"


### PR DESCRIPTION
Upgrade the LDES consumer for Ghent's instance snapshot feed to the newest version. This version should be more stable and is actively maintained compare to the one currently used.

Furthermore, this new version correctly supports obtaining the first node/page from the LDES feed itself instead of hardcoding it in the configured viewpoint URL. This allows Ghent to apply a retention policy which may cause the page number of the first page to change over time.

## How to test
The easiest way to test whether (new) instance snapshot are actually retrieved is to load a production data backup from production your local stack and point the LDES consumer to Ghent's production LDES feed:

1. Obtain and load a backup following your preferred method. At the time of writing the most recent instance snapshots were published today (07 May 2025), so any previous backup should do.
2. In your docker overwrite set `LDES_ENDPOINT_VIEW` to the PROD URL mentioned in the changelog.
3. Launch the stack.
4. The logs for the `ldes-consumer-instancesnapshot-gent` service should show the service started correctly. (By default the service does not show much, you can set `LOG_LEVEL` to "debug" if you want more output.)
5. The logs for `lpdc-management` service should show it is processing new snapshots, it may take a few minutes for the cronjob to kick in. You should see entries similar to

``` shell
lpdc-management-1  | 2025-05-07T12:02:53.788860721Z InstanceSnapshotToInstanceMergerDomainService|New versioned resource found: https://stad.gent/id/product/7acbc7dd-12b2-ea11-a853-005056a8c14b/2025-05-07T11:54:27.450853566 of service https://stad.gent/id/product/7acbc7dd-12b2-ea11-a853-005056a8c14b
```

6. You can check via the frontend, logging in as municipality Ghent, that it contains product instances that are more recently modified then whatever time your backup was from.

If you want to check the data in the landing zone graph, something like the following query can be used to list the snapshots:

``` sparql
PREFIX ipdc-lpdc: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
PREFIX schemas: <https://schema.org/>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

SELECT DISTINCT ?s ?date ?status
WHERE {
  GRAPH <http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/gent> {
    ?s a ipdc-lpdc:InstancePublicServiceSnapshot ;
       schema:dateModified ?modified .
    OPTIONAL {
      ?mark ext:processedSnapshot ?s;
            schema:dateCreated ?date ;
            schema:status ?status .
    }
  }
} ORDER BY DESC(?modified)
LIMIT 5
```


Alternatively, you can wait until Ghent publishes a new snapshot on whatever feed (QA/PROD) you have configured. But this might take a while :wink:

If you do not want to (or cannot) use PROD data/backup, it possible to test the behaviour by manually removing a snapshot resource from the landing zone graph. As the new consumer does not carry over state and just re-consumes the whole feed, any removed snapshot should reappear after you launched the consumer. Note that removing not enough data or too much may lead to unexpected behaviour from the `lpdc-management` service. To fully remove an already processed snapshot and its processing mark you can use the following query:

``` sparql
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>

DELETE {
  GRAPH <http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/gent> {
    ?snapshot ?snapshotP ?snapshotO .
    ?mark ext:processedSnapshot ?snapshot ;
          ?markP ?markO .
  }
} WHERE {
  GRAPH <http://mu.semte.ch/graphs/lpdc/instancesnapshots-ldes-data/gent> {
    ?snapshot ?snapshotP ?snapshotO .
    ?mark ext:processedSnapshot ?snapshot ;
          ?markP ?markO .
  }
  VALUES ?snapshot {
    <SNAPSHOT_URI>
  }
}
```

## Related tickets
- LPDC-1414
- LPDC-1400 (original incident)