### PR TITLE
chore: rename PZ Rivierenland to PZ Bornem/Puurs-Sint-Amands/Mechelen/Willebroek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 ## Unreleased
 
+## v0.27.2 (2025-06-TODO)
+### Backend
+- datafix: rename rename PZ Rivierenland to PZ Bornem/Puurs-Sint-Amands/Mechelen/Willebroek [LPDC-1424]
+### Deploy notes
+#### Docker commands
+- `drc restart migrations; drc logs -ft --tail=200 migrations`
+
 ## v0.27.1 (2025-06-02)
 ### Frontend
 - Bump to [v0.22.1](https://github.com/lblod/frontend-lpdc/blob/development/CHANGELOG.md#v0221-2025-05-28)

--- a/config/migrations/2025/20250612150745-chore--rename-pz-rivierenland.sparql
+++ b/config/migrations/2025/20250612150745-chore--rename-pz-rivierenland.sparql
@@ -1,0 +1,18 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?pzRivierenland skos:prefLabel ?oldLabel .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?pzRivierenland skos:prefLabel "PZ Bornem/Puurs-Sint-Amands/Mechelen/Willebroek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?pzRivierenland skos:prefLabel ?oldLabel .
+    VALUES ?pzRivierenland {
+      <http://data.lblod.info/id/bestuurseenheden/81dd243d-f66c-4157-b105-5407aa83cb62>
+    }
+  }
+}

--- a/config/migrations/2025/20250612150745-chore--rename-pz-rivierenland.sparql
+++ b/config/migrations/2025/20250612150745-chore--rename-pz-rivierenland.sparql
@@ -1,4 +1,5 @@
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 
 DELETE {
   GRAPH <http://mu.semte.ch/graphs/public> {
@@ -13,6 +14,30 @@ DELETE {
     ?pzRivierenland skos:prefLabel ?oldLabel .
     VALUES ?pzRivierenland {
       <http://data.lblod.info/id/bestuurseenheden/81dd243d-f66c-4157-b105-5407aa83cb62>
+    }
+  }
+}
+;
+# Also update the mock-login information
+DELETE {
+  GRAPH ?g {
+    ?person foaf:familyName ?oldFamilyName .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?person foaf:familyName "PZ Bornem/Puurs-Sint-Amands/Mechelen/Willebroek" .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?person a foaf:Person ;
+            foaf:member ?pzRivierenland ;
+            foaf:familyName ?oldFamilyName .
+    VALUES ?pzRivierenland {
+      <http://data.lblod.info/id/bestuurseenheden/81dd243d-f66c-4157-b105-5407aa83cb62>
+    }
+    VALUES ?g {
+      <http://mu.semte.ch/graphs/organizations/81dd243d-f66c-4157-b105-5407aa83cb62>
+      <http://mu.semte.ch/graphs/public>
     }
   }
 }


### PR DESCRIPTION
An administrative unit was renamed in OP/Loket since it was initially imported into LPDC. Since users do want to use this administrative unit in their product instances, we update its name to match the one used in OP/Loket. That way users can more easily find it and don't have to remember multiple names.

Note, this PR concerns only one specific administrative unit about which users complained. Since LPDC does not (yet) consume data from OP, there are most likely more name discrepancies. We opted **not** to resolve these pro-actively, see ticket for more background.

## How to test
1. Launch your local LPDC stack, or restart the migrations service if already running
2. Log in, any user with product instances should do
3. Open a product instance
4. Optional, if the selected product instance has state "Verzonden", click the "Product opnieuw bewerken" button in the top right and confirm in the modal.
5. Go the to "Eigenschappen" tab of the product instance
6. In the section "Bevoegdheid", when searching in the fields "Bevoegde overheid" or "Uitvoerende overheid" the organisation should appear as an option under the new name. For example, when typing "bornem" the suggestions in the dropdown should include "PZ Bornem/Puurs-Sint-Amands/Mechelen/Willebroek (Politiezone)". Searching for something like "rivierenland" should no longer suggest "PZ Rivierenland (Politiezone)". (It does suggest other organisations that contains the term "rivierenland" in there name.)


On the mock-login page, searching for (part of) the new name should result in an entry "Politiezone PZ Bornem/Puurs-Sint-Amands/Mechelen/Willebroek"

When (mock-)logged in as the renamed organisation the user name in the top-right corner should contain the new name.

## Related tickets
- LPDC-1424