### PR TITLE
Add migration to cleanup the empty contactpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@
 
 ### Backend
 - Ensure restart directive is set for lpdc-management [DL-6508]
+- Migration to cleanup empty contactpoints [DL-6752]
 
+### Deploy notes
+
+```
+drc pull lpdc lpdc-management; drc up -d lpdc lpdc-management
+drc restart migrations; drc logs -ft --tail=200 migrations
+```
 
 ## v0.29.1 (2025-08-01)
 ### Backend

--- a/config/migrations/2025/20250814192225-cleanup-empty-contactpoints.sparql
+++ b/config/migrations/2025/20250814192225-cleanup-empty-contactpoints.sparql
@@ -1,0 +1,43 @@
+PREFIX schema: <http://schema.org/>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX lpdcExt: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
+PREFIX m8g: <http://data.europa.eu/m8g/>
+
+DELETE {
+  GRAPH ?g {
+    ?service m8g:hasContactPoint ?contactPoint .
+
+    ?contactPoint ?p1 ?o1 .
+
+    ?address ?p2 ?o2 .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?service m8g:hasContactPoint ?contactPoint .
+
+    ?contactPoint a schema:ContactPoint .
+
+    FILTER NOT EXISTS { ?contactPoint schema:telephone ?tel . }
+    FILTER NOT EXISTS { ?contactPoint schema:email ?email . }
+    FILTER NOT EXISTS { ?contactPoint schema:url ?url . }
+    FILTER NOT EXISTS { ?contactPoint schema:openingHours ?openingHours . }
+
+    # check for either no address at all OR an address that is completely empty
+    FILTER NOT EXISTS {
+      ?contactPoint lpdcExt:address ?address .
+      { ?address adres:Straatnaam ?straat . }
+      UNION
+      { ?address adres:gemeentenaam ?gemeente . }
+      UNION
+      { ?address adres:Adresvoorstelling.huisnummer ?huisnummer . }
+      UNION
+      { ?address adres:postcode ?postcode . }
+    }
+
+    ?contactPoint ?p1 ?o1 .
+    OPTIONAL {
+      ?contactPoint lpdcExt:address ?address .
+      ?address ?p2 ?o2 .
+    }
+  }
+}


### PR DESCRIPTION
## ID
DL-6752

## Description

With the changes of https://github.com/lblod/lpdc-management-service/pull/72 we don't create empty contactpoint objects anymore, this migration cleans up any that already exist.

## Testing instructions

Setup local stack, use `lblod/lpdc-management-service:0.50.5` to still be able to create empty contactpoints.
-> Create instance with a) empty contactpoint, b) empty contactpoint with an empty address as well
-> both a and b should be removed after running the migration