### PR TITLE
LPDC-1637: reorderd dispatcher so that file download doesn't hit cach…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Run LPDC Complete Report sequentially [LPDC-1631]
+- LPDC rapporten - downloads are json files instead of csv [LPDC-1637]
 
 ### Frontend
 - Bump to [v0.30.0](https://github.com/lblod/frontend-lpdc/releases/tag/v0.30.0) [LPDC-1619]
@@ -12,8 +13,8 @@
 
 ### Deploy notes
 ```bash
-drc restart report-generation
-drc pull lpdc lpdc-management && drc up -d lpdc lpdc-management
+drc restart report-generation dispatcher
+drc pull lpdc lpdc-management dashboard file && drc up -d lpdc lpdc-management dashboard file
 ```
 
 ### Database

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -83,6 +83,10 @@ defmodule Dispatcher do
     forward conn, path, "http://resource/reports/"
   end
 
+  get "/files/:id/download", @any do
+      forward conn, [], "http://file/files/" <> id <> "/download"
+    end
+
   get "/files/*path", @json do
     forward conn, path, "http://cache/files/"
   end
@@ -92,10 +96,6 @@ defmodule Dispatcher do
   end
 
   # File service
-
-  get "/files/:id/download", @any do
-    forward conn, [], "http://file/files/" <> id <> "/download"
-  end
 
   post "/files/*path", @any do
     forward conn, path, "http://file/files/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,7 +200,7 @@ services:
     logging: *default-logging
 
   dashboard:
-    image: lblod/frontend-dashboard:1.9.0
+    image: lblod/frontend-dashboard:1.10.0
     environment:
       EMBER_LOGIN_ROUTE: "acmidm-login"
       EMBER_DISABLE_ERRORS: "true"
@@ -232,7 +232,7 @@ services:
     logging: *default-logging
 
   file:
-    image: cecemel/file-service:3.3.0
+    image: semtech/mu-file-service:3.4.0
     depends_on:
       migrations:
         condition: service_healthy


### PR DESCRIPTION
- reorder dispatcher so that file download requests hit the file-service and not the cache.
- bumps to mu-file-service and frontend-dashboard

TO TEST:
- start stack
- generate a report via curl command
- download report via dashboard and check if it returns in csv format. Use chrome because this issue doesn't happen via firefox