### PR TITLE
Lpdc 1627 mail if sending instance fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Run LPDC Complete Report sequentially [LPDC-1631]
+- Mail if sending instance fails [LPDC-1627]
 
 ### Frontend
 - Bump to [v0.30.0](https://github.com/lblod/frontend-lpdc/releases/tag/v0.30.0) [LPDC-1619]
@@ -12,8 +13,8 @@
 
 ### Deploy notes
 ```bash
-drc restart report-generation
-drc pull lpdc lpdc-management && drc up -d lpdc lpdc-management
+drc restart report-generation error-alert deltanotifier migrations
+drc pull lpdc lpdc-management lpdc-publish && drc up -d lpdc lpdc-management lpdc-publish
 ```
 
 ### Database

--- a/config/delta/error-alert.js
+++ b/config/delta/error-alert.js
@@ -1,27 +1,52 @@
 export default [
     {
-    match: {
-        predicate: {
-            type: 'uri',
+        match: {
+            predicate: {
+                type: 'uri',
                 value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+            },
+            object: {
+                type: 'uri',
+                value: 'http://open-services.net/ns/core#Error'
+            },
+            graph: {
+                type: 'uri',
+                value: 'http://mu.semte.ch/graphs/lpdc/ipdc-feedback-publication-errors'
+            }
         },
-        object: {
-            type: 'uri',
-                value:'http://open-services.net/ns/core#Error'
+        callback: {
+            url: 'http://error-alert/delta',
+            method: 'POST'
         },
-        graph: {
-            type: 'uri',
-            value: 'http://mu.semte.ch/graphs/lpdc/ipdc-feedback-publication-errors'
-        }
-    },
-    callback: {
-        url: 'http://error-alert/delta',
-            method:'POST'
-    },
-    options: {
-        resourceFormat: 'v0.0.1',
+        options: {
+            resourceFormat: 'v0.0.1',
             gracePeriod: 1000,
             ignoreFromSelf: true
-    }
-}
+        }
+    },
+    {
+        match: {
+            predicate: {
+                type: 'uri',
+                value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+            },
+            object: {
+                type: 'uri',
+                value: 'http://open-services.net/ns/core#Error'
+            },
+            graph: {
+                type: 'uri',
+                value: 'http://mu.semte.ch/graphs/lpdc/ipdc-publication-errors'
+            }
+        },
+        callback: {
+            url: 'http://error-alert/delta',
+            method: 'POST'
+        },
+        options: {
+            resourceFormat: 'v0.0.1',
+            gracePeriod: 1000,
+            ignoreFromSelf: true
+        }
+    },
 ];

--- a/config/error-alert/config.json
+++ b/config/error-alert/config.json
@@ -1,5 +1,6 @@
 {
   "creators": [
-    "http://lblod.data.gift/services/lpdc-feedback-management-service"
+    "http://lblod.data.gift/services/lpdc-feedback-management-service",
+    "http://lblod.data.gift/services/lpdc-publish"
   ]
 }

--- a/config/migrations/2026/20260421141649-rename-predicates-instancePublicationError.sparql
+++ b/config/migrations/2026/20260421141649-rename-predicates-instancePublicationError.sparql
@@ -1,0 +1,29 @@
+PREFIX lpdc: <http://data.lblod.info/vocabularies/lpdc/>
+PREFIX schema: <http://schema.org/>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX oslc: <http://open-services.net/ns/core#>
+
+
+DELETE {
+    GRAPH <http://mu.semte.ch/graphs/lpdc/ipdc-publication-errors> {
+        ?publicationError schema:error ?errorMessage .
+        ?publicationError dct:source ?instanceIri .
+        ?publicationError schema:dateCreated ?dateCreated .
+    }
+}
+INSERT {
+    GRAPH <http://mu.semte.ch/graphs/lpdc/ipdc-publication-errors> {
+        ?publicationError oslc:largePreview ?errorMessage .
+        ?publicationError dct:references ?instanceIri .
+        ?publicationError dct:created ?dateCreated .
+    }
+}
+WHERE {
+    GRAPH <http://mu.semte.ch/graphs/lpdc/ipdc-publication-errors> {
+        ?publicationError a lpdc:InstancePublicationError .
+        ?publicationError schema:error ?errorMessage .
+        ?publicationError dct:source ?instanceIri .
+        ?publicationError schema:dateCreated ?dateCreated .
+    }
+}
+

--- a/config/reports/instancesStuckinPublishingForLPDCReport.js
+++ b/config/reports/instancesStuckinPublishingForLPDCReport.js
@@ -26,18 +26,20 @@ export default {
       PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
       PREFIX lpdcExt: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
       PREFIX lpdc:    <http://data.lblod.info/vocabularies/lpdc/>
+      PREFIX oslc: <http://open-services.net/ns/core#>
+
       
       SELECT DISTINCT ?instanceIri ?type ?title ?bestuurseenheidLabel ?classificatieLabel ?errorCode ?errorMessage ?dateCreated ?dateSent WHERE {
             GRAPH <http://mu.semte.ch/graphs/lpdc/ipdc-publication-errors> {
                 ?publicationError a lpdc:InstancePublicationError .
                 ?publicationError http:statusCode ?errorCode .
-                ?publicationError schema:error ?errorMessage .
-                ?publicationError dct:source ?instanceIri .
+                ?publicationError oslc:largePreview ?errorMessage .
+                ?publicationError dct:references ?instanceIri .
                 OPTIONAL {
                     ?publicationError dct:title ?title .
                 }
                 ?publicationError foaf:owner ?bestuurseenheidIri .
-                ?publicationError schema:dateCreated ?dateCreated .
+                ?publicationError dct:created ?dateCreated .
                 ?publicationError as:formerType ?type .
                 OPTIONAL {
                     ?publicationError schema:dateSent ?dateSent .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -303,8 +303,6 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
-    links:
-      - virtuoso:database # We want to go directly to virtuoso database
 
   ldes-consumer-conceptsnapshot-ipdc:
     image: redpencil/ldes-consumer:feature-custom-member-processing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -285,7 +285,7 @@ services:
       retries: 200
 
   lpdc-publish:
-    image: lblod/lpdc-publish-service:0.21.0
+    image: lblod/lpdc-publish-service:0.21.1
     depends_on:
       migrations:
         condition: service_healthy


### PR DESCRIPTION
- Changed InstancePublicationError structure to follow the defined error structure used in loket-error-alert-service
- Added migration to modify existing  InstancePublicationErrors to follow this new structure
- Edit to instancesStuckinPublishingForLPDCReport
- Edit to error-alert config + delta rules


TO TEST:
- rsync from test
- replace lpdc-publish image with a local build of https://github.com/lblod/lpdc-publish-service/tree/LPDC-1627-mail-if-sending-instance-fails
- start stack
- check that when lpdc-publish fails to send an instance 5 times to ipdc, it creates an error which leads to a mail being created via error-alert/deliver-email-service
- check that instancesStuckinPublishingForLPDCReport still works as intended


NOTE:
To enable delta generations from lpdc-publish, I removed the direct link to the virtuoso. I could not find why this was needed for this service and I don't seem to get any issues when testing the service without this link.