### PR TITLE
LPDC-1650: Herziening nodig afzetten voor update u/je-omzetting bij IPDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Run LPDC Complete Report sequentially [LPDC-1631]
 - Mail if sending instance fails [LPDC-1627]
 - LPDC rapporten - downloads are json files instead of csv [LPDC-1637]
+- Add option to turn herziening nodig off [LPDC-1650]
 
 ### Frontend
 - Bump to [v0.30.0](https://github.com/lblod/frontend-lpdc/releases/tag/v0.30.0) [LPDC-1619]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 ## Unreleased
+- Add option to turn herziening nodig off. To turn this on put DISABLE_REVIEW_STATUS_UPDATES: "true" in docker-compose.override [LPDC-1650]
+
 ### Management
 - Bump to [v0.54.2](https://github.com/lblod/lpdc-management-service/releases/tag/v0.54.2) [LPDC-1644]
 - Bump to [v0.54.3](https://github.com/lblod/lpdc-management-service/releases/tag/v0.54.3) [LPDC-1661]
+- Bump to [v0.54.4](https://github.com/lblod/lpdc-management-service/releases/tag/v0.54.4) [LPDC-1650]
 - Bump acm-login service [DL-7346]
 
 ### Deploy notes
@@ -15,7 +18,6 @@ drc pull lpdc-management login-lpdc login-dashboard && drc up -d lpdc-management
 - Run LPDC Complete Report sequentially [LPDC-1631]
 - Mail if sending instance fails [LPDC-1627]
 - LPDC rapporten - downloads are json files instead of csv [LPDC-1637]
-- Add option to turn herziening nodig off [LPDC-1650]
 
 ### Frontend
 - Bump to [v0.30.0](https://github.com/lblod/frontend-lpdc/releases/tag/v0.30.0) [LPDC-1619]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,6 +273,7 @@ services:
       INSTANCE_SNAPSHOT_PROCESSING_CRON_PATTERN: "*/1 * * * *" # run the job every minute
       CONCEPT_SNAPSHOT_PROCESSING_CRON_PATTERN: "*/1 * * * *" # run the job every minute
       ENABLE_MUNICIPALITY_MERGER_FLAG: "false"
+      ENABLE_REVIEW_STATUS_UPDATES: "true"  # put "false" to turn herziening nodig off
     labels:
       - "logging=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -259,7 +259,7 @@ services:
     depends_on:
       migrations:
         condition: service_healthy
-    image: lblod/lpdc-management-service:0.54.3
+    image: lblod/lpdc-management-service:0.54.4
     environment:
       LOG_SPARQL_ALL: "false"
       LOG_SPARQL_QUERIES: "false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,7 +273,6 @@ services:
       INSTANCE_SNAPSHOT_PROCESSING_CRON_PATTERN: "*/1 * * * *" # run the job every minute
       CONCEPT_SNAPSHOT_PROCESSING_CRON_PATTERN: "*/1 * * * *" # run the job every minute
       ENABLE_MUNICIPALITY_MERGER_FLAG: "false"
-      ENABLE_REVIEW_STATUS_UPDATES: "true"  # put "false" to turn herziening nodig off
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
Added an option to turn off herziening nodig

### Test

1. Simulate a new conceptSnapShot appearing in lpdc
2. See if the herziening nodig is not there if you set the ENABLE_REVIEW_STATUS_UPDATES in the override in app-lpdc-management
3. See if the herziening nodig stays if you set it to true.

Also need: https://github.com/lblod/lpdc-management-service/pull/89
Note: also need to add the lpdc-management-service bump once that has been released
