### PR TITLE
LPDC-1676: Two times a year report

### DIFF
--- a/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
+++ b/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
@@ -18,6 +18,7 @@ INSERT DATA {
       lpdcExt:hasNotificationRuleConfig <http://data.lblod.info/id/notification-rule-configs/b2c3d4e5-f6a7-8901-bcde-f12345678901> ;
       lpdcExt:hasNotificationRuleConfig <http://data.lblod.info/id/notification-rule-configs/1b58b0f3-582d-43f2-a6e5-8da247223f58> ;
       lpdcExt:hasNotificationRuleConfig <http://data.lblod.info/id/notification-rule-configs/43768631-fdde-4a41-934c-9936d73b0bd9> ;
+      lpdcExt:hasNotificationRuleConfig <http://data.lblod.info/id/notification-rule-configs/e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf> ;
       lpdcExt:notificationInstance <http://data.lblod.info/id/public-service/2bc7d6b7-d134-459d-9a66-7dea329170ca> ;
       lpdcExt:notificationInstance <http://data.lblod.info/id/public-service/de97836e-8a72-456e-912b-42ff79008b4c> ;
       lpdcExt:notificationInstance <http://data.lblod.info/id/public-service/1babf63a-a053-4c61-b1b8-adfe00c84c96> ;
@@ -40,5 +41,11 @@ INSERT DATA {
       mu:uuid "43768631-fdde-4a41-934c-9936d73b0bd9" ;
       lpdcExt:notificationFrequency "weekly" ;
       lpdcExt:hasEnabledRule <http://lblod.data.gift/concepts/906311f3-f9f0-4b02-80de-d339df39a4ad> .
+    
+    <http://data.lblod.info/id/notification-rule-configs/e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf>
+      a lpdcExt:NotificationRuleConfig ;
+      mu:uuid "e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf" ;
+      lpdcExt:notificationFrequency "twice a year" ;
+      lpdcExt:hasEnabledRule <http://lblod.data.gift/concepts/e2dcc9bf-e105-47ab-90ac-5e8119f464bc> .
   }
 }

--- a/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
+++ b/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
@@ -45,7 +45,6 @@ INSERT DATA {
     <http://data.lblod.info/id/notification-rule-configs/e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf>
       a lpdcExt:NotificationRuleConfig ;
       mu:uuid "e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf" ;
-      lpdcExt:notificationFrequency "twice a year" ;
       lpdcExt:hasEnabledRule <http://lblod.data.gift/concepts/e2dcc9bf-e105-47ab-90ac-5e8119f464bc> .
   }
 }

--- a/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
+++ b/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
@@ -44,6 +44,7 @@ INSERT DATA {
     <http://data.lblod.info/id/notification-rule-configs/e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf>
       a lpdcExt:NotificationRuleConfig ;
       mu:uuid "e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf" ;
+      lpdcExt:notificationFrequency "bi-annual" ;
       lpdcExt:hasEnabledRule <http://lblod.data.gift/concepts/634522c3-f5bd-4f53-82d3-983b7cbbdb10> .
   }
 }

--- a/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
+++ b/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
@@ -44,6 +44,6 @@ INSERT DATA {
     <http://data.lblod.info/id/notification-rule-configs/e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf>
       a lpdcExt:NotificationRuleConfig ;
       mu:uuid "e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf" ;
-      lpdcExt:hasEnabledRule <http://lblod.data.gift/concepts/e2dcc9bf-e105-47ab-90ac-5e8119f464bc> .
+      lpdcExt:hasEnabledRule <http://lblod.data.gift/concepts/634522c3-f5bd-4f53-82d3-983b7cbbdb10> .
   }
 }

--- a/config/migrations/2026/20260623132643-create-email-notification-rules.ttl
+++ b/config/migrations/2026/20260623132643-create-email-notification-rules.ttl
@@ -38,5 +38,5 @@
     skos:topConceptOf <http://lblod.data.gift/concept-schemes/8b9fcaa2-e346-4e48-b9b7-757a6f6acb04> ;
     skos:inScheme     <http://lblod.data.gift/concept-schemes/8b9fcaa2-e346-4e48-b9b7-757a6f6acb04> ;
     skos:prefLabel    "Status rapport"@nl ;
-    skos:definition   "Status rapport"@nl .
+    skos:definition   "Halfjaarlijks statusrapport beschikbaar op 1 maart en 1 september"@nl .
 

--- a/config/migrations/2026/20260623132643-create-email-notification-rules.ttl
+++ b/config/migrations/2026/20260623132643-create-email-notification-rules.ttl
@@ -32,3 +32,11 @@
     skos:prefLabel    "U/je"@nl ;
     skos:definition   "U/je werd gewijzigd"@nl .
 
+<http://lblod.data.gift/concepts/e2dcc9bf-e105-47ab-90ac-5e8119f464bc>
+    a                 skos:Concept ;
+    mu:uuid           "e2dcc9bf-e105-47ab-90ac-5e8119f464bc" ;
+    skos:topConceptOf <http://lblod.data.gift/concept-schemes/8b9fcaa2-e346-4e48-b9b7-757a6f6acb04> ;
+    skos:inScheme     <http://lblod.data.gift/concept-schemes/8b9fcaa2-e346-4e48-b9b7-757a6f6acb04> ;
+    skos:prefLabel    "Statusrapport"@nl ;
+    skos:definition   "Halfjaarlijks statusrapport beschikbaar op 1 januari en 1 juli"@nl .
+


### PR DESCRIPTION
Added a rule for the two times a year report and added it to the mock data dev-migration

### To test:
Put a force true in the isStatusReportDue function
```
export function isStatusReportDue(forceTrue = false) { //TODO: Added a forcetrue for testing, must delete later
  if (forceTrue) return true;
```
and put true in the call of the function in processStatusReport
```
    !isStatusReportDue()
```

Look at the logs for lpdc-email-notification-service and deliver-email-service.

This PR goes together with:  https://github.com/lblod/lpdc-email-notification-service/pull/3
