### PR TITLE
[LPDC-1673]: add deltanotifier config for adhoc notifications

### DIFF
--- a/config/delta/emailNotificationService.js
+++ b/config/delta/emailNotificationService.js
@@ -1,0 +1,90 @@
+export default [
+  {
+    match: {
+      predicate: {
+        type: "uri",
+        value:
+          "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#feedbackAvailable",
+      },
+      object: {
+        type: "literal",
+        value: "true",
+      },
+    },
+    callback: {
+      url: "http://lpdc-email-notification-service/delta-feedback",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 1000,
+      ignoreFromSelf: false,
+    },
+  },
+  {
+    match: {
+      predicate: {
+        type: "uri",
+        value:
+          "https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#needsConversionFromFormalToInformal",
+      },
+      object: {
+        type: "literal",
+        value: "true",
+      },
+    },
+    callback: {
+      url: "http://lpdc-email-notification-service/delta-formal-informal",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 1000,
+      ignoreFromSelf: false,
+    },
+  },
+  {
+    match: {
+      predicate: {
+        type: "uri",
+        value: "http://mu.semte.ch/vocabularies/ext/reviewStatus",
+      },
+      object: {
+        type: "uri",
+        value:
+          "http://lblod.data.gift/concepts/review-status/concept-gewijzigd",
+      },
+    },
+    callback: {
+      url: "http://lpdc-email-notification-service/delta-review-status",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 1000,
+      ignoreFromSelf: false,
+    },
+  },
+  {
+    match: {
+      predicate: {
+        type: "uri",
+        value: "http://mu.semte.ch/vocabularies/ext/reviewStatus",
+      },
+      object: {
+        type: "uri",
+        value:
+          "http://lblod.data.gift/concepts/review-status/concept-gearchiveerd",
+      },
+    },
+    callback: {
+      url: "http://lpdc-email-notification-service/delta-review-status",
+      method: "POST",
+    },
+    options: {
+      resourceFormat: "v0.0.1",
+      gracePeriod: 1000,
+      ignoreFromSelf: false,
+    },
+  },
+];

--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -1,9 +1,11 @@
-import resource from './resource';
+import resource from "./resource";
 import feedbackManagementService from "./feedbackManagementService";
+import emailNotificationService from "./emailNotificationService";
 import errorAlert from "./error-alert";
 
 export default [
   ...resource,
-    ...feedbackManagementService,
-    ...errorAlert
+  ...feedbackManagementService,
+  ...emailNotificationService,
+  ...errorAlert,
 ];


### PR DESCRIPTION
## ID

LPDC-1673

## Description

Add deltanotifier config for the adhoc notifications. I've split up the callback endpoints into 3, for each action:
- feedback
- formalInformal
- reviewStatus

I'm hoping the matching is correct for the booleans, couldn't find similar examples elsewhere.

## Testing instructions

See [notifications pr](https://github.com/lblod/lpdc-email-notification-service/pull/5)