### PR TITLE
[LPDC-1696]: add the bestuurseenheid directly to the notificationPreference

### DIFF
--- a/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
+++ b/config/dev-migrations/20260623183536-mock-notification-leuven.sparql
@@ -5,6 +5,7 @@ PREFIX schema: <http://schema.org/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX org: <http://www.w3.org/ns/org#>
 
 INSERT DATA {
   GRAPH <http://mu.semte.ch/graphs/organizations/c648ea5d12626ee3364a02debb223908a71e68f53d69a7a7136585b58a083e77/LoketLB-LPDCGebruiker> {
@@ -13,6 +14,7 @@ INSERT DATA {
       mu:uuid "a1b2c3d4-e5f6-7890-abcd-ef1234567890" ;
       schema:email "test@example.com" ;
       dct:creator <http://data.lblod.info/id/persoon/f8056f91a397696befe8984d893517b9> ;
+      org:linkedTo <http://data.lblod.info/id/bestuurseenheden/c648ea5d12626ee3364a02debb223908a71e68f53d69a7a7136585b58a083e77> ;
       lpdcExt:notificationsEnabled true ;
       lpdcExt:hasNotificationRuleConfig <http://data.lblod.info/id/notification-rule-configs/b2c3d4e5-f6a7-8901-bcde-f12345678901> ;
       lpdcExt:hasNotificationRuleConfig <http://data.lblod.info/id/notification-rule-configs/1b58b0f3-582d-43f2-a6e5-8da247223f58> ;
@@ -40,7 +42,7 @@ INSERT DATA {
       mu:uuid "43768631-fdde-4a41-934c-9936d73b0bd9" ;
       lpdcExt:notificationFrequency "weekly" ;
       lpdcExt:hasEnabledRule <http://lblod.data.gift/concepts/906311f3-f9f0-4b02-80de-d339df39a4ad> .
-    
+
     <http://data.lblod.info/id/notification-rule-configs/e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf>
       a lpdcExt:NotificationRuleConfig ;
       mu:uuid "e9c6c061-d53e-4c04-9dfd-b3bb4f1fbccf" ;

--- a/config/resources/notification-preference.lisp
+++ b/config/resources/notification-preference.lisp
@@ -19,7 +19,9 @@
               (public-service :via ,(s-prefix "lpdcExt:notificationInstance")
                               :as "instances"))
   :has-one `((gebruiker :via ,(s-prefix "dct:creator")
-                        :as "gebruiker"))
+                        :as "gebruiker")
+             (bestuurseenheid :via ,(s-prefix "org:linkedTo")
+                        :as "bestuurseenheid"))
   :resource-base (s-url "http://data.lblod.info/id/notification-preferences/")
   :features '(include-uri)
   :on-path "notification-preferences"


### PR DESCRIPTION
## ID

LPDC-1696

## Description

Link the bestuurseenheid directly to the notificationPreference, since logging in with acm/idm doesn't have the foaf:member link to the bestuurseenheid.

