### PR TITLE
LPDC - 1685 LPDC dashboard - report all fields does not run any more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+- LPDC dashboard - report all fields does not run anymore [LPDC-1685]
+
+### Deploy notes
+```
+drc restart report-generation
+```
+
 ## v0.37.3 (2026-08-03)
 - Bump frontend to version [0.32.0](https://github.com/lblod/frontend-lpdc/releases/tag/v0.32.0) [LPDC-1688]
 ### Management

--- a/config/reports/lpdcBestuurseenheidCompleteReport.js
+++ b/config/reports/lpdcBestuurseenheidCompleteReport.js
@@ -56,8 +56,7 @@ function generateDetailsUri(uri) {
 
       WHERE {
         VALUES ?uriPubliekeDienstverlening {<${uri}>}
-        ?uriPubliekeDienstverlening a lpdcExt:InstancePublicService ;
-                                      schema:dateModified ?aangepastOp .
+        ?uriPubliekeDienstverlening a lpdcExt:InstancePublicService .
 
         OPTIONAL {
           ?uriPubliekeDienstverlening pav:createdBy ?uriBestuurseenheid .
@@ -77,6 +76,7 @@ function generateDetailsUri(uri) {
         OPTIONAL { ?uriPubliekeDienstverlening lpdcExt:needsConversionFromFormalToInformal ?vergtOmzettingNaarInformeel }
         OPTIONAL { ?uriPubliekeDienstverlening lpdcExt:forMunicipalityMerger ?voorGemeentelijkeFusie }
         OPTIONAL { ?uriPubliekeDienstverlening schema:dateSent ?verstuurdOp }
+        OPTIONAL { ?uriPubliekeDienstverlening schema:dateModified ?aangepastOp }
         OPTIONAL { ?uriPubliekeDienstverlening dct:title ?titel }
         OPTIONAL { ?uriPubliekeDienstverlening schema:dateCreated ?aangemaaktOp }
         OPTIONAL { ?uriPubliekeDienstverlening lpdcExt:dutchLanguageVariant ?versie }
@@ -415,7 +415,7 @@ async function fetchAllDataForUri(uri) {
       typeBestuurseenheid: details.typeBestuurseenheid?.value  || '',
       aangemaaktOp: details.aangemaaktOp?.value || '',
       aangemaaktDoor: details.aangemaaktDoor?.value || '',
-      aangepastOp: details.aangepastOp.value,
+      aangepastOp: details.aangepastOp?.value  || '',
       aangepastDoor: details.aangepastDoor?.value || '',
       IPDCConceptID: details.IPDCConceptID?.value || '',
       reviewStatus: details.reviewStatus?.value || '',


### PR DESCRIPTION
**Code change:** Made dateModified optional so it doesn't break the code. 
_Important: Below is a prod query I want to deploy on prod to fix empty instance, also check that!_

### To test
1. get a prod Copy
2. run the lpdcBestuurseenheidCompleteReport and see if it runs without failing

### Extra
Checked with Geertrui for the empty instance (only an URI in the data, nothing else) that caused it to fail. This instance was archived in IPDC, and can be deleted. For this I want to run a local query on prod:
```
PREFIX lpdcExt: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
DELETE {
  GRAPH <http://mu.semte.ch/graphs/organizations/47857958-7d00-47e0-ae83-00d914eca93f/LoketLB-LPDCGebruiker> {
    <http://data.lblod.info/id/public-service/9e6681e3-4d0f-4919-b3d9-3d023fd6a827> a lpdcExt:InstancePublicService .
  }
}
WHERE {
  GRAPH <http://mu.semte.ch/graphs/organizations/47857958-7d00-47e0-ae83-00d914eca93f/LoketLB-LPDCGebruiker> {
    <http://data.lblod.info/id/public-service/9e6681e3-4d0f-4919-b3d9-3d023fd6a827> a lpdcExt:InstancePublicService .
  }
}
```
To test this: Run the query and see if this URI has been deleted from the DB

