### PR TITLE
[LPDC-1655]: add new isYearOld flag

### DIFF
--- a/config/migrations/2026/20260820103953-cleanup-job-flag-year-old-instances.graph
+++ b/config/migrations/2026/20260820103953-cleanup-job-flag-year-old-instances.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2026/20260820103953-cleanup-job-flag-year-old-instances.ttl
+++ b/config/migrations/2026/20260820103953-cleanup-job-flag-year-old-instances.ttl
@@ -1,0 +1,36 @@
+PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
+PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+<http://data.lblod.info/id/cleanup-job/65c88814-100f-4e6e-b691-8311c1749166> a cleanup:Job ;
+  mu:uuid "65c88814-100f-4e6e-b691-8311c1749166" ;
+  dcterms:title "Flag instances not updated in a year`" ;
+  cleanup:randomQuery """
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX lpdcExt: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
+    PREFIX schema: <http://schema.org/>
+
+    DELETE {
+      GRAPH ?bestuurseenheidGraph {
+        ?instance lpdcExt:isYearOld ?currentValue .
+      }
+    }
+    INSERT {
+      GRAPH ?bestuurseenheidGraph {
+        ?instance lpdcExt:isYearOld true .
+      }
+    } WHERE {
+      GRAPH ?bestuurseenheidGraph {
+        ?instance a lpdcExt:InstancePublicService ;
+                  schema:dateModified ?lastModifiedOn .
+        OPTIONAL { ?instance lpdcExt:isYearOld ?currentValue . }
+      }
+      BIND(xsd:date(NOW() - "P1Y"^^xsd:duration) AS ?lastYear)
+      FILTER(?lastModifiedOn <= ?lastYear)
+      FILTER(
+          STRSTARTS(STR(?bestuurseenheidGraph), "http://mu.semte.ch/graphs/organizations/") &&
+          STRENDS(STR(?bestuurseenheidGraph), "/LoketLB-LPDCGebruiker")
+      )
+    }
+    """ ;
+  cleanup:cronPattern "25 21 * * *" .

--- a/config/resources/lpdc.lisp
+++ b/config/resources/lpdc.lisp
@@ -51,7 +51,8 @@
                 (:review-status-modified-date :datetime ,(s-prefix "lpdcExt:reviewStatusModifiedDate"))
                 (:formal-informal-modified-date :datetime ,(s-prefix "lpdcExt:formalInformalModifiedDate"))
                 (:feedback-modified-date :datetime ,(s-prefix "lpdcExt:feedbackModifiedDate"))
-                (:date-sent :datetime ,(s-prefix "schema:dateSent")))
+                (:date-sent :datetime ,(s-prefix "schema:dateSent"))
+                (:is-year-old :boolean ,(s-prefix "lpdcExt:isYearOld")))
   :has-one `((concept :via ,(s-prefix "ext:reviewStatus")
                       :as "review-status")
              (conceptual-public-service :via ,(s-prefix "dct:source")
@@ -65,7 +66,7 @@
   :has-many `((feedback :via ,(s-prefix "skos:primarySubject")
                         :inverse t
                         :as "feedback")
-              (notification-preference :via ,(s-prefix "lpdcExt:notificationInstance") 
+              (notification-preference :via ,(s-prefix "lpdcExt:notificationInstance")
                                        :inverse t
                                        :as "notification-preferences"))
   :resource-base (s-url "http://data.lblod.info/id/public-service/")


### PR DESCRIPTION
## ID

LPDC-1655

## Description

Add isYearOld flag and daily dbcleanup script to flag any instances that are >1y old as true.

## Testing

Setup TEST data with https://github.com/lblod/lpdc-management-service/pull/99 and frontend (WIP, creating PR in a bit)

Run the dbcleanup query to immediately flag year old instances:
```
    PREFIX prov: <http://www.w3.org/ns/prov#>
    PREFIX lpdcExt: <https://productencatalogus.data.vlaanderen.be/ns/ipdc-lpdc#>
    PREFIX schema: <http://schema.org/>

    DELETE {
      GRAPH ?bestuurseenheidGraph {
        ?instance lpdcExt:isYearOld ?currentValue .
      }
    }
    INSERT {
      GRAPH ?bestuurseenheidGraph {
        ?instance lpdcExt:isYearOld true .
      }
    } WHERE {
      GRAPH ?bestuurseenheidGraph {
        ?instance a lpdcExt:InstancePublicService ;
                  schema:dateModified ?lastModifiedOn .
        OPTIONAL { ?instance lpdcExt:isYearOld ?currentValue . }
      }
      BIND(xsd:date(NOW() - "P1Y"^^xsd:duration) AS ?lastYear)
      FILTER(?lastModifiedOn <= ?lastYear)
      FILTER(
          STRSTARTS(STR(?bestuurseenheidGraph), "http://mu.semte.ch/graphs/organizations/") &&
          STRENDS(STR(?bestuurseenheidGraph), "/LoketLB-LPDCGebruiker")
      )
    }
```

Go to the frontend and filter for the year old, open some instances, alert banner should appear at the top of the page, see LPDC-1652 comments for what we settled on.
